### PR TITLE
Use own DNS names

### DIFF
--- a/.github/workflows/environment-main-deploy.yaml
+++ b/.github/workflows/environment-main-deploy.yaml
@@ -56,6 +56,7 @@ jobs:
         variables: |
           environment="${{ vars.ENVIRONMENT }}"
           saml_metadata_url="${{ secrets.SAML_METADATA_URL }}"
+          domain_name="${{ vars.DOMAIN_NAME }}"
         backend_config:
           bucket=${{ vars.STATE_BUCKET }}
           key=${{ vars.ENVIRONMENT }}/terraform.tfstate

--- a/.github/workflows/environment-main-plan.yaml
+++ b/.github/workflows/environment-main-plan.yaml
@@ -53,6 +53,7 @@ jobs:
         variables: |
           environment="${{ vars.ENVIRONMENT }}"
           saml_metadata_url="${{ secrets.SAML_METADATA_URL }}"
+          domain_name="${{ vars.DOMAIN_NAME }}"
         backend_config:
           bucket=${{ vars.STATE_BUCKET }}
           key=${{ vars.ENVIRONMENT }}/terraform.tfstate

--- a/README.md
+++ b/README.md
@@ -18,9 +18,12 @@ Wildsea companion app
 
 * Create an AWS Account for deployment
   * Define a profile in your `~/.aws/config` to access it as admin for the initial setup deploys
+* Create a route53 hosted zone, enable DNSSEC, and perform the necessary delegations
 * Create an S3 bucket `terraform-state-<accountid>`
 * Create `terraform/environment/aws/terraform.tfvars`
   * Add `workspace = "<your github org>"` to the vars file
+* Create `terraform/environment/wildsea-dev/terraform.tfvars`
+  * Add `domain = "<domain>"` to the route53 zone domain name
 * Run `.AWS_PROFILE=<profile> ./terraform/environment/github/aws.sh <aws account id>`
 * Log into Codacy, and connect the repo
   * Configure the rule to maximum
@@ -40,6 +43,7 @@ Wildsea companion app
 * Run `.AWS_PROFILE=<profile> ./terraform/environment/github/deploy.sh <aws account id>`
 * Install <https://github.com/apps/renovate> into the repo
 * Go into the two environments, and set a secret called `SAML_METADATA_URL` with the metadata URL for you SAML (See Jumpcloud for an example)
+* Go into the two environments, and set a variable `DOMAIN_NAME` with the DNS zone set up earlier
 
 To automate:
 

--- a/terraform/environment/wildsea-dev/main.tf
+++ b/terraform/environment/wildsea-dev/main.tf
@@ -5,6 +5,11 @@ variable "saml_metadata_url" {
   default     = ""
 }
 
+variable "domain_name" {
+  description = "DNS Domain to put records into"
+  type        = string
+}
+
 locals {
   app_name = "Wildsea"
   prefix   = "${local.app_name}-dev"
@@ -24,10 +29,26 @@ provider "aws" {
   }
 }
 
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+  default_tags {
+    tags = {
+      Application = local.prefix
+    }
+  }
+}
+
 module "wildsea" {
   source = "../../module/wildsea"
 
   saml_metadata_url = var.saml_metadata_url
   prefix            = local.prefix
+  domain_name       = var.domain_name
   log_level         = "ALL"
+
+  providers = {
+    aws           = aws
+    aws.us-east-1 = aws.us-east-1
+  }
 }

--- a/terraform/environment/wildsea/main.tf
+++ b/terraform/environment/wildsea/main.tf
@@ -10,6 +10,11 @@ variable "saml_metadata_url" {
   default     = "TODO"
 }
 
+variable "domain_name" {
+  description = "DNS Domain to put records into"
+  type        = string
+}
+
 locals {
   app_name = "Wildsea"
   prefix   = "${local.app_name}-${var.environment}"
@@ -29,10 +34,26 @@ provider "aws" {
   }
 }
 
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+  default_tags {
+    tags = {
+      Application = local.prefix
+    }
+  }
+}
+
 module "wildsea" {
   source = "../../module/wildsea"
 
   saml_metadata_url = var.saml_metadata_url
   prefix            = local.prefix
-  log_level         = "ERROR"
+  domain_name       = var.domain_name
+  log_level         = "ALL"
+
+  providers = {
+    aws           = aws
+    aws.us-east-1 = aws.us-east-1
+  }
 }

--- a/terraform/module/wildsea/cognito.tf
+++ b/terraform/module/wildsea/cognito.tf
@@ -30,8 +30,8 @@ resource "aws_cognito_user_pool_client" "cognito" {
   generate_secret                      = false
   explicit_auth_flows                  = ["ALLOW_REFRESH_TOKEN_AUTH", "ALLOW_USER_PASSWORD_AUTH", "ALLOW_USER_SRP_AUTH"]
   allowed_oauth_flows_user_pool_client = true
-  callback_urls                        = ["http://localhost:5173/", "https://${aws_cloudfront_distribution.cdn.domain_name}/"]
-  logout_urls                          = ["http://localhost:5173/", "https://${aws_cloudfront_distribution.cdn.domain_name}/"]
+  callback_urls                        = ["http://localhost:5173/", "https://${local.cdn_domain_name}/"]
+  logout_urls                          = ["http://localhost:5173/", "https://${local.cdn_domain_name}/"]
   allowed_oauth_flows                  = ["code"]
   allowed_oauth_scopes                 = ["openid", "aws.cognito.signin.user.admin"]
   supported_identity_providers         = [var.saml_metadata_url == "" ? "COGNITO" : aws_cognito_identity_provider.idp[0].provider_name]

--- a/terraform/module/wildsea/main.tf
+++ b/terraform/module/wildsea/main.tf
@@ -1,3 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = ">= 5.0"
+      configuration_aliases = [aws, aws.us-east-1]
+    }
+  }
+}
+
 data "aws_region" "current" {}
 data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
@@ -13,7 +23,7 @@ variable "saml_metadata_url" {
 }
 
 variable "enable_waf" {
-  description = "Enable WAF? Has codt implications"
+  description = "Enable WAF? Has cost implications"
   type        = bool
   default     = false
 }
@@ -22,4 +32,18 @@ variable "log_level" {
   description = "Appsync log level"
   type        = string
   default     = "ERROR"
+}
+
+variable "domain_name" {
+  description = "Domain name"
+  type        = string
+}
+
+locals {
+  appsync_domain_name = "api-${lower(var.prefix)}.${var.domain_name}"
+  cdn_domain_name     = var.prefix == "Wildsea-primary" ? var.domain_name : "${lower(var.prefix)}.${var.domain_name}"
+}
+
+data "aws_route53_zone" "zone" {
+  name = var.domain_name
 }

--- a/terraform/module/wildsea/output.tf
+++ b/terraform/module/wildsea/output.tf
@@ -11,7 +11,10 @@ output "cognito_web_client_id" {
 }
 
 output "graphql_uri" {
-  value = aws_appsync_graphql_api.graphql.uris["GRAPHQL"]
+  //value = aws_appsync_graphql_api.graphql.uris["GRAPHQL"]
+  value = "https://${local.appsync_domain_name}/graphql"
+  //value = "https://${aws_cloudfront_distribution.cdn.domain_name}/graphql"
+  //value = "https://${local.cdn_domain_name}/graphql"
 }
 
 output "region" {

--- a/terraform/module/wildsea/ui-cdn.tf
+++ b/terraform/module/wildsea/ui-cdn.tf
@@ -14,31 +14,53 @@ data "aws_cloudfront_cache_policy" "cache_policy" {
   name = "Managed-CachingOptimized"
 }
 
+data "aws_cloudfront_cache_policy" "caching_disabled" {
+  name = "Managed-CachingDisabled"
+}
+
 data "aws_cloudfront_origin_request_policy" "request_policy" {
   name = "Managed-CORS-S3Origin"
+}
+
+data "aws_cloudfront_origin_request_policy" "all_viewer_policy" {
+  name = "Managed-AllViewer"
+}
+
+data "aws_cloudfront_origin_request_policy" "all_viewer_except_host_header_policy" {
+  name = "Managed-AllViewerExceptHostHeader"
 }
 
 data "aws_cloudfront_response_headers_policy" "headers_policy" {
   name = "Managed-CORS-with-preflight-and-SecurityHeadersPolicy"
 }
 
-# nosemgrep: aws-insecure-cloudfront-distribution-tls-version // Can't set with default certificate
 resource "aws_cloudfront_distribution" "cdn" {
-  # checkov:skip=CKV2_AWS_42:Not set up custom domain yet
   # checkov:skip=CKV_AWS_86:Chosen not to enable access logging yet
   # checkov:skip=CKV2_AWS_47:Log4j is irrelvant for S3 origins
   # checkov:skip=CKV_AWS_310:Not enabling origin failover for S3 origin
   # checkov:skip=CKV_AWS_68:Not enabled WAF yet - $$$
-  # checkov:skip=CKV_AWS_174:Cannot set TLS version with default certificate
   origin {
     domain_name              = aws_s3_bucket.ui.bucket_regional_domain_name
     origin_id                = aws_s3_bucket.ui.id
     origin_access_control_id = aws_cloudfront_origin_access_control.cdn.id
   }
 
+  //  origin {
+  //    domain_name = aws_appsync_domain_name.api.appsync_domain_name
+  //    //domain_name = split("/", aws_appsync_graphql_api.graphql.uris["GRAPHQL"])[2]
+  //    origin_id = "appsync"
+  //
+  //    custom_origin_config {
+  //      http_port              = 80
+  //      https_port             = 443
+  //      origin_protocol_policy = "https-only"
+  //      origin_ssl_protocols   = ["TLSv1.2"]
+  //    }
+  //  }
+
   enabled             = true
   default_root_object = "index.html"
-  #aliases - TODO Use our own DNS name
+  aliases             = [local.cdn_domain_name]
 
   default_cache_behavior {
     allowed_methods            = ["GET", "HEAD", "OPTIONS"]
@@ -50,6 +72,20 @@ resource "aws_cloudfront_distribution" "cdn" {
     response_headers_policy_id = data.aws_cloudfront_response_headers_policy.headers_policy.id
   }
 
+  //  ordered_cache_behavior {
+  //    path_pattern     = "/graphql"
+  //    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+  //    cached_methods   = ["GET", "HEAD"]
+  //    target_origin_id = "appsync"
+  //
+  //    viewer_protocol_policy = "redirect-to-https"
+  //    cache_policy_id        = data.aws_cloudfront_cache_policy.caching_disabled.id
+  //    //origin_request_policy_id = aws_cloudfront_origin_request_policy.websocket_policy.id
+  //    //origin_request_policy_id   = data.aws_cloudfront_origin_request_policy.all_viewer_policy.id
+  //    origin_request_policy_id = data.aws_cloudfront_origin_request_policy.all_viewer_except_host_header_policy.id
+  //    //response_headers_policy_id = aws_cloudfront_response_headers_policy.cors_policy.id
+  //  }
+
   restrictions {
     geo_restriction {
       restriction_type = "none"
@@ -57,13 +93,104 @@ resource "aws_cloudfront_distribution" "cdn" {
   }
 
   viewer_certificate {
-    cloudfront_default_certificate = true
-    #minimum_protocol_version       = "TLSv1.2_2021" # Not available on default certificate
+    acm_certificate_arn      = aws_acm_certificate.cdn.arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
   }
 
   #TODO - logging
 
   tags = {
     Name = local.cdn_name
+  }
+}
+
+//resource "aws_cloudfront_origin_request_policy" "websocket_policy" {
+//  name    = "WebSocketPolicy"
+//  comment = "Policy for WebSocket connections"
+//  cookies_config {
+//    cookie_behavior = "all"
+//  }
+//  headers_config {
+//    header_behavior = "whitelist"
+//    headers {
+//      items = ["Sec-WebSocket-Key", "Sec-WebSocket-Version", "Sec-WebSocket-Protocol", "Sec-WebSocket-Accept", "Origin", "Referer"]
+//    }
+//  }
+//  query_strings_config {
+//    query_string_behavior = "all"
+//  }
+//}
+
+//resource "aws_cloudfront_response_headers_policy" "cors_policy" {
+//  name    = "cors-policy"
+//  comment = "CORS policy for GraphQL API"
+//
+//  cors_config {
+//    access_control_allow_credentials = true
+//
+//    access_control_allow_headers {
+//      items = ["Authorization", "Content-Type", "Origin"]
+//    }
+//
+//    access_control_allow_methods {
+//      items = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+//    }
+//
+//    access_control_allow_origins {
+//      items = [
+//        "http://localhost:5173",
+//        "https://${local.cdn_domain_name}",
+//      ]
+//    }
+//
+//    origin_override = true
+//  }
+//}
+
+resource "aws_acm_certificate" "cdn" {
+  provider = aws.us-east-1
+
+  domain_name       = local.cdn_domain_name
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "cdn_validate" {
+  for_each = {
+    for dvo in aws_acm_certificate.cdn.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = data.aws_route53_zone.zone.zone_id
+}
+
+resource "aws_acm_certificate_validation" "cdn" {
+  provider = aws.us-east-1
+
+  certificate_arn         = aws_acm_certificate.cdn.arn
+  validation_record_fqdns = [for record in aws_route53_record.cdn_validate : record.fqdn]
+}
+
+resource "aws_route53_record" "cdn" {
+  zone_id = data.aws_route53_zone.zone.zone_id
+  name    = local.cdn_domain_name
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.cdn.domain_name
+    zone_id                = aws_cloudfront_distribution.cdn.hosted_zone_id
+    evaluate_target_health = false
   }
 }


### PR DESCRIPTION
Use own DNS Zone for GraphQL and Cloudfront.

Could not get GraphQL behind the Cloudfront - still working on that

Have to see if we can get stricter about CORS,