### PR TITLE
Add dice roll modal for Delta Green skills

### DIFF
--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -1944,3 +1944,212 @@ button:hover {
     font-size: 11px;
   }
 }
+
+/* Dice Roll Modal */
+.modal-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.modal-content {
+  background: white;
+  border-radius: 8px;
+  max-width: 500px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.dice-roll-modal {
+  min-width: 400px;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 20px 10px;
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 18px;
+  color: #333;
+}
+
+.modal-close-button {
+  background: none;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  padding: 0;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #666;
+}
+
+.modal-close-button:hover {
+  color: #333;
+  background-color: #f5f5f5;
+  border-radius: 4px;
+}
+
+.modal-body {
+  padding: 20px;
+}
+
+.form-group {
+  margin-bottom: 20px;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 5px;
+  font-weight: 500;
+  color: #333;
+}
+
+.form-group input,
+.form-group select {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 14px;
+  box-sizing: border-box;
+}
+
+.form-group input:focus,
+.form-group select:focus {
+  outline: none;
+  border-color: #007bff;
+  box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
+}
+
+.form-help {
+  font-size: 12px;
+  color: #666;
+  margin-top: 5px;
+}
+
+.form-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.btn {
+  padding: 8px 16px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: all 0.2s;
+}
+
+.btn-primary {
+  background-color: #007bff;
+  color: white;
+  border-color: #007bff;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background-color: #0056b3;
+  border-color: #0056b3;
+}
+
+.btn-secondary {
+  background-color: #6c757d;
+  color: white;
+  border-color: #6c757d;
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background-color: #545b62;
+  border-color: #545b62;
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.roll-result-container {
+  text-align: center;
+}
+
+.roll-result-container h3 {
+  margin: 0 0 20px 0;
+  color: #333;
+}
+
+/* Skill dice buttons */
+.dice-button {
+  background: none;
+  border: none;
+  font-size: 16px;
+  cursor: pointer;
+  padding: 2px 6px;
+  margin-left: 8px;
+  border-radius: 4px;
+  transition: all 0.2s;
+  opacity: 0.7;
+}
+
+.dice-button:hover {
+  opacity: 1;
+  background-color: #f8f9fa;
+  transform: scale(1.1);
+}
+
+.dice-button:active {
+  transform: scale(0.95);
+}
+
+.skills-col-roll {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.roll-display {
+  font-weight: 500;
+}
+
+@media screen and (width <= 768px) {
+  .modal-backdrop {
+    padding: 10px;
+  }
+  
+  .dice-roll-modal {
+    min-width: unset;
+  }
+  
+  .modal-header {
+    padding: 15px 15px 10px;
+  }
+  
+  .modal-body {
+    padding: 15px;
+  }
+  
+  .dice-button {
+    font-size: 14px;
+    padding: 1px 4px;
+    margin-left: 4px;
+  }
+}

--- a/ui/src/components/DiceRollFormatter.tsx
+++ b/ui/src/components/DiceRollFormatter.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { useIntl } from 'react-intl';
+import { DiceRoll } from "../../../appsync/graphql";
+import { RollTypes, Grades } from "../../../graphql/lib/constants/rollTypes";
+
+const formatGrade = (grade: string, rollType: string, intl: any) => {
+  if (rollType === RollTypes.SUM) {
+    return { emoji: '🎲', text: '', className: 'grade-neutral', borderClassName: 'border-neutral' };
+  }
+  
+  switch (grade) {
+    case Grades.CRITICAL_SUCCESS:
+      return { emoji: '🔥', text: intl.formatMessage({ id: 'diceRoll.grade.CRITICAL_SUCCESS' }), className: 'grade-critical-success', borderClassName: 'border-critical-success' };
+    case Grades.SUCCESS:
+      return { emoji: '✅', text: intl.formatMessage({ id: 'diceRoll.grade.SUCCESS' }), className: 'grade-success', borderClassName: 'border-success' };
+    case Grades.FAILURE:
+      return { emoji: '❌', text: intl.formatMessage({ id: 'diceRoll.grade.FAILURE' }), className: 'grade-failure', borderClassName: 'border-failure' };
+    case Grades.FUMBLE:
+      return { emoji: '💀', text: intl.formatMessage({ id: 'diceRoll.grade.FUMBLE' }), className: 'grade-fumble', borderClassName: 'border-fumble' };
+    default:
+      return { emoji: '🎲', text: '', className: 'grade-neutral', borderClassName: 'border-neutral' };
+  }
+};
+
+const formatDiceDetails = (diceList: any[]) => {
+  if (diceList.length === 1) {
+    return diceList[0].value.toString();
+  }
+  
+  const values = diceList.map(die => die.value);
+  const sum = values.reduce((a, b) => a + b, 0);
+  return `${values.join(' + ')} = ${sum}`;
+};
+
+interface DiceRollFormatterProps {
+  roll: DiceRoll;
+}
+
+export const DiceRollFormatter: React.FC<DiceRollFormatterProps> = ({ roll }) => {
+  const intl = useIntl();
+  const gradeInfo = formatGrade(roll.grade, roll.rollType, intl);
+  const playerName = roll.playerName;
+  
+  return (
+    <div className="dice-roll-formatted">
+      <div className="roll-header">
+        {playerName} {intl.formatMessage({ id: 'diceRoll.rolled' })}{roll.action ? ` ${roll.action}` : ''}
+      </div>
+      
+      {roll.rollType === RollTypes.SUM ? (
+        <div className="roll-result">
+          {gradeInfo.emoji} {intl.formatMessage({ id: 'diceRoll.total' }, { value: roll.value })}
+        </div>
+      ) : (
+        <div className="roll-result">
+          🎯 {intl.formatMessage({ id: 'diceRoll.target' }, { target: roll.target })} → {intl.formatMessage({ id: 'diceRoll.result' }, { value: roll.value })} → <span className={gradeInfo.className}>{gradeInfo.emoji} {gradeInfo.text}</span>
+        </div>
+      )}
+      
+      <div className="roll-details">
+        {formatDiceDetails(roll.diceList)}
+      </div>
+    </div>
+  );
+};
+
+export { formatGrade, formatDiceDetails };

--- a/ui/src/components/DiceRollModal.tsx
+++ b/ui/src/components/DiceRollModal.tsx
@@ -1,0 +1,229 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { generateClient } from "aws-amplify/api";
+import { rollDiceMutation } from "../../../appsync/schema";
+import { RollDiceInput, DiceRoll } from "../../../appsync/graphql";
+import { RollTypes } from "../../../graphql/lib/constants/rollTypes";
+import { DiceRollFormatter } from './DiceRollFormatter';
+
+interface DiceRollModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  gameId: string;
+  skillName: string;
+  skillValue: number;
+  onRollComplete?: (grade: string) => void;
+}
+
+export const DiceRollModal: React.FC<DiceRollModalProps> = ({
+  isOpen,
+  onClose,
+  gameId,
+  skillName,
+  skillValue,
+  onRollComplete
+}) => {
+  const intl = useIntl();
+  const [action, setAction] = useState(`for ${skillName}`);
+  const [target, setTarget] = useState(skillValue);
+  const [isRolling, setIsRolling] = useState(false);
+  const [rollResult, setRollResult] = useState<DiceRoll | null>(null);
+  const modalRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setAction(`for ${skillName}`);
+      setTarget(skillValue);
+      setRollResult(null);
+      setIsRolling(false);
+      
+      setTimeout(() => {
+        const firstInput = modalRef.current?.querySelector('input') as HTMLElement;
+        firstInput?.focus();
+      }, 100);
+    }
+  }, [isOpen, skillName, skillValue]);
+
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isOpen && !isRolling) {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscape);
+      document.body.style.overflow = 'hidden';
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+      document.body.style.overflow = '';
+    };
+  }, [isOpen, isRolling, onClose]);
+
+  const targetOptions = [-40, -30, -20, -10, 0, 10, 20, 30, 40].map(modifier => {
+    const value = Math.max(0, Math.min(99, skillValue + modifier));
+    return { modifier, value };
+  });
+
+  const handleRoll = async () => {
+    setIsRolling(true);
+    try {
+      const client = generateClient();
+      const input: RollDiceInput = {
+        gameId,
+        dice: [{ type: 'd100', size: 100 }],
+        rollType: RollTypes.DELTA_GREEN,
+        target,
+        action: action.trim() || undefined,
+      };
+      
+      const result = await client.graphql({
+        query: rollDiceMutation,
+        variables: { input },
+      });
+
+      if ('data' in result && result.data?.rollDice) {
+        const rollResult = result.data.rollDice;
+        setRollResult(rollResult);
+        if (onRollComplete) {
+          onRollComplete(rollResult.grade);
+        }
+      }
+    } catch (error) {
+      console.error('Error rolling dice:', error);
+    } finally {
+      setIsRolling(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (!isRolling) {
+      onClose();
+    }
+  };
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget && !isRolling) {
+      onClose();
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div 
+      className="modal-backdrop"
+      onClick={handleBackdropClick}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="dice-roll-modal-title"
+    >
+      <div 
+        ref={modalRef}
+        className="modal-content dice-roll-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="modal-header">
+          <h2 id="dice-roll-modal-title">
+            <FormattedMessage id="diceRollModal.title" />
+          </h2>
+          <button
+            ref={closeButtonRef}
+            className="modal-close-button"
+            onClick={handleClose}
+            disabled={isRolling}
+            aria-label={intl.formatMessage({ id: 'diceRollModal.close' })}
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="modal-body">
+          {!rollResult ? (
+            <form onSubmit={(e) => { e.preventDefault(); handleRoll(); }}>
+              <div className="form-group">
+                <label htmlFor="action-input">
+                  <FormattedMessage id="diceRollModal.action" />
+                </label>
+                <input
+                  id="action-input"
+                  type="text"
+                  value={action}
+                  onChange={(e) => setAction(e.target.value)}
+                  disabled={isRolling}
+                  placeholder={intl.formatMessage({ id: 'diceRollModal.actionPlaceholder' })}
+                  aria-describedby="action-help"
+                />
+                <div id="action-help" className="form-help">
+                  <FormattedMessage id="diceRollModal.actionHelp" />
+                </div>
+              </div>
+
+              <div className="form-group">
+                <label htmlFor="target-select">
+                  <FormattedMessage id="diceRollModal.target" />
+                </label>
+                <select
+                  id="target-select"
+                  value={target}
+                  onChange={(e) => setTarget(parseInt(e.target.value))}
+                  disabled={isRolling}
+                  aria-describedby="target-help"
+                >
+                  {targetOptions.map(({ modifier, value }) => (
+                    <option key={modifier} value={value}>
+                      {value}% {modifier !== 0 && `(${modifier > 0 ? '+' : ''}${modifier}%)`}
+                    </option>
+                  ))}
+                </select>
+                <div id="target-help" className="form-help">
+                  <FormattedMessage 
+                    id="diceRollModal.targetHelp" 
+                    values={{ skillValue: skillValue }}
+                  />
+                </div>
+              </div>
+
+              <div className="form-actions">
+                <button
+                  type="submit"
+                  className="btn btn-primary"
+                  disabled={isRolling}
+                  aria-describedby="roll-button-help"
+                >
+                  {isRolling ? (
+                    <FormattedMessage id="diceRollModal.rolling" />
+                  ) : (
+                    <FormattedMessage id="diceRollModal.roll" />
+                  )}
+                </button>
+                <div id="roll-button-help" className="form-help">
+                  <FormattedMessage id="diceRollModal.rollHelp" />
+                </div>
+              </div>
+            </form>
+          ) : (
+            <div className="roll-result-container">
+              <h3>
+                <FormattedMessage id="diceRollModal.result" />
+              </h3>
+              <DiceRollFormatter roll={rollResult} />
+              <div className="form-actions">
+                <button
+                  className="btn btn-secondary"
+                  onClick={handleClose}
+                  autoFocus
+                >
+                  <FormattedMessage id="diceRollModal.close" />
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/ui/src/diceRollPanel.tsx
+++ b/ui/src/diceRollPanel.tsx
@@ -6,66 +6,12 @@ import { diceRolledSubscription, rollDiceMutation } from "../../appsync/schema";
 import { FormattedMessage, useIntl } from 'react-intl';
 import { RollTypes, Grades } from "../../graphql/lib/constants/rollTypes";
 import { RollDiceInput } from "../../appsync/graphql";
+import { DiceRollFormatter, formatGrade } from './components/DiceRollFormatter';
 
 interface DiceRollPanelProps {
   gameId: string;
 }
 
-const formatGrade = (grade: string, rollType: string, intl: any) => {
-  if (rollType === RollTypes.SUM) {
-    return { emoji: '🎲', text: '', className: 'grade-neutral', borderClassName: 'border-neutral' };
-  }
-  
-  switch (grade) {
-    case Grades.CRITICAL_SUCCESS:
-      return { emoji: '🔥', text: intl.formatMessage({ id: 'diceRoll.grade.CRITICAL_SUCCESS' }), className: 'grade-critical-success', borderClassName: 'border-critical-success' };
-    case Grades.SUCCESS:
-      return { emoji: '✅', text: intl.formatMessage({ id: 'diceRoll.grade.SUCCESS' }), className: 'grade-success', borderClassName: 'border-success' };
-    case Grades.FAILURE:
-      return { emoji: '❌', text: intl.formatMessage({ id: 'diceRoll.grade.FAILURE' }), className: 'grade-failure', borderClassName: 'border-failure' };
-    case Grades.FUMBLE:
-      return { emoji: '💀', text: intl.formatMessage({ id: 'diceRoll.grade.FUMBLE' }), className: 'grade-fumble', borderClassName: 'border-fumble' };
-    default:
-      return { emoji: '🎲', text: '', className: 'grade-neutral', borderClassName: 'border-neutral' };
-  }
-};
-
-const formatDiceDetails = (diceList: any[]) => {
-  if (diceList.length === 1) {
-    return diceList[0].value.toString();
-  }
-  
-  const values = diceList.map(die => die.value);
-  const sum = values.reduce((a, b) => a + b, 0);
-  return `${values.join(' + ')} = ${sum}`;
-};
-
-const formatDiceRoll = (roll: DiceRoll, intl: any) => {
-  const gradeInfo = formatGrade(roll.grade, roll.rollType, intl);
-  const playerName = roll.playerName;
-  
-  return (
-    <div className="dice-roll-formatted">
-      <div className="roll-header">
-        {playerName} {intl.formatMessage({ id: 'diceRoll.rolled' })}{roll.action ? ` ${roll.action}` : ''}
-      </div>
-      
-      {roll.rollType === RollTypes.SUM ? (
-        <div className="roll-result">
-          {gradeInfo.emoji} {intl.formatMessage({ id: 'diceRoll.total' }, { value: roll.value })}
-        </div>
-      ) : (
-        <div className="roll-result">
-          🎯 {intl.formatMessage({ id: 'diceRoll.target' }, { target: roll.target })} → {intl.formatMessage({ id: 'diceRoll.result' }, { value: roll.value })} → <span className={gradeInfo.className}>{gradeInfo.emoji} {gradeInfo.text}</span>
-        </div>
-      )}
-      
-      <div className="roll-details">
-        {formatDiceDetails(roll.diceList)}
-      </div>
-    </div>
-  );
-};
 
 export const DiceRollPanel: React.FC<DiceRollPanelProps> = ({ gameId }) => {
   const [diceRolls, setDiceRolls] = useState<DiceRoll[]>([]);
@@ -232,7 +178,7 @@ export const DiceRollPanel: React.FC<DiceRollPanelProps> = ({ gameId }) => {
                       role="listitem"
                       aria-label={intl.formatMessage({ id: 'diceRollPanel.rollBy' }, { playerName: roll.playerName })}
                     >
-                      {formatDiceRoll(roll, intl)}
+                      <DiceRollFormatter roll={roll} />
                     </li>
                   );
                 })}

--- a/ui/src/translations.ts
+++ b/ui/src/translations.ts
@@ -126,6 +126,7 @@ export const messages = {
     'deltaGreenSkills.skill': 'Skill',
     'deltaGreenSkills.roll': 'Roll %',
     'deltaGreenSkills.hasUsedFlag': 'Has used flag',
+    'deltaGreenSkills.rollDice': 'Roll dice for {skillName}',
 
     // Dice roll panel translations
     'diceRollPanel.title': 'Dice Rolls',
@@ -155,6 +156,19 @@ export const messages = {
     // Animation characters
     'diceRoll.animation.firework': '✨',
     'diceRoll.animation.skull': '💀',
+
+    // Dice roll modal
+    'diceRollModal.title': 'Roll Dice',
+    'diceRollModal.close': 'Close',
+    'diceRollModal.action': 'Action',
+    'diceRollModal.actionPlaceholder': 'What are you rolling for?',
+    'diceRollModal.actionHelp': 'Describe what this roll is for (optional)',
+    'diceRollModal.target': 'Target Number',
+    'diceRollModal.targetHelp': 'Base skill value: {skillValue}%. Select a modifier to apply.',
+    'diceRollModal.roll': 'Roll Dice',
+    'diceRollModal.rolling': 'Rolling...',
+    'diceRollModal.rollHelp': 'Roll a d100 against the target number',
+    'diceRollModal.result': 'Roll Result',
 
     // Common section translations
     'sectionObject.updateError': 'Failed to update the section',


### PR DESCRIPTION
## Summary
- Add dice roll modal component for Delta Green skills with dice buttons next to skill values
- Extract shared dice roll formatting logic for reuse across components  
- Auto-mark skills as "used" when rolls result in failure/fumble (respects hasUsedFlag property)

## Features
- 🎲 Dice buttons appear next to skill values > 0%
- 📝 Modal pre-populates with skill name ("for {skill-name}")
- 🎯 Target number defaults to skill % with modifier options (-40% to +40%, clamped 0-99%)
- 🎰 Performs Delta Green d100 roll vs target number
- ✅ Auto-marks skills as "used" on failure/fumble (only for skills with used flags)
- 🌐 Full i18n support with proper ARIA labels for accessibility
- 📱 Responsive modal design with proper form controls

## Technical Details
- Created reusable `DiceRollModal` component in `ui/src/components/`
- Extracted `DiceRollFormatter` component from `diceRollPanel.tsx` for shared use
- Added callback system for post-roll actions (marking skills as used)
- Fixed form input box-sizing to prevent modal overflow
- Uses existing GraphQL mutations and roll type constants

## Test plan
- [x] Dice buttons appear next to skills with values > 0%
- [x] Modal opens with correct skill name and target value
- [x] Target dropdown shows all modifier options correctly
- [x] Roll performs Delta Green d100 vs target calculation
- [x] Results display using shared formatter component
- [x] Skills with used flags get marked on failure/fumble
- [x] Skills without used flags (like Unnatural) are not marked
- [x] Modal is responsive and inputs don't overflow
- [x] All UI text uses i18n keys and ARIA labels work

🤖 Generated with [Claude Code](https://claude.ai/code)