### PR TITLE
Add post-session upgrades for Delta Green skills and improve mobile UX

### DIFF
--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -1116,25 +1116,15 @@ button:hover {
   gap: 0;
   align-items: center;
   border: 1px solid #ddd;
-  border-bottom: none;
+  border-radius: 4px;
   padding: 0;
+  margin-bottom: 2px;
   break-inside: avoid;
   page-break-inside: avoid;
 }
 
 .delta-green-skills-grid.no-used-column .skills-item {
   grid-template-columns: 1fr 80px;
-}
-
-.skills-item:first-child {
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
-}
-
-.skills-item:last-child {
-  border-bottom: 1px solid #ddd;
-  border-bottom-left-radius: 4px;
-  border-bottom-right-radius: 4px;
 }
 
 .skills-col-used,
@@ -1295,6 +1285,45 @@ button:hover {
     grid-template-columns: 1fr;
     gap: 5px;
   }
+}
+
+/* Post-session upgrades button styling */
+.section-items .post-session-upgrades {
+  grid-column: 1 / -1;
+}
+
+.post-session-upgrades {
+  margin-top: 15px;
+  text-align: center;
+}
+
+.post-session-upgrades-button {
+  background-color: #28a745;
+  color: white;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.post-session-upgrades-button:hover {
+  background-color: #218838;
+}
+
+.post-session-upgrades-button:active {
+  background-color: #1e7e34;
+}
+
+.post-session-upgrades-button:disabled {
+  background-color: #6c757d;
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.post-session-upgrades-button:disabled:hover {
+  background-color: #6c757d;
 }
 
 /* Dice Roll Panel Styles */

--- a/ui/src/components/DiceRollModal.tsx
+++ b/ui/src/components/DiceRollModal.tsx
@@ -30,6 +30,7 @@ export const DiceRollModal: React.FC<DiceRollModalProps> = ({
   const [isRolling, setIsRolling] = useState(false);
   const [rollResult, setRollResult] = useState<DiceRoll | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const rollButtonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     if (isOpen) {
@@ -39,8 +40,7 @@ export const DiceRollModal: React.FC<DiceRollModalProps> = ({
       setIsRolling(false);
       
       setTimeout(() => {
-        const firstInput = document.querySelector('.dice-roll-modal input') as HTMLElement;
-        firstInput?.focus();
+        rollButtonRef.current?.focus();
       }, 100);
     }
   }, [isOpen, skillValue, initialAction]);
@@ -160,6 +160,7 @@ export const DiceRollModal: React.FC<DiceRollModalProps> = ({
 
               <div className="form-actions">
                 <button
+                  ref={rollButtonRef}
                   type="submit"
                   className="btn btn-primary"
                   disabled={isRolling}

--- a/ui/src/sectionDeltaGreenSkills.tsx
+++ b/ui/src/sectionDeltaGreenSkills.tsx
@@ -116,6 +116,27 @@ export const SectionDeltaGreenSkills: React.FC<SectionDefinition> = (props) => {
     }
   };
 
+  const handlePostSessionUpgrades = async (
+    content: SectionTypeDeltaGreenSkills,
+    setContent: React.Dispatch<React.SetStateAction<SectionTypeDeltaGreenSkills>>,
+    updateSection: (updatedSection: Partial<SheetSection>) => Promise<void>,
+  ) => {
+    const newItems = content.items.map(item => {
+      if (item.used && item.hasUsedFlag !== false) {
+        return {
+          ...item,
+          roll: Math.min(99, item.roll + 1),
+          used: false
+        };
+      }
+      return item;
+    });
+    
+    const newContent = { ...content, items: newItems };
+    setContent(newContent);
+    await updateSection({ content: JSON.stringify(newContent) });
+  };
+
   const renderItems = (
     content: SectionTypeDeltaGreenSkills,
     mayEditSheet: boolean,
@@ -130,42 +151,57 @@ export const SectionDeltaGreenSkills: React.FC<SectionDefinition> = (props) => {
     const sortedItems = [...filteredItems].sort((a, b) => a.name.localeCompare(b.name));
 
     const hasAnyUsedFlags = sortedItems.some(item => item.hasUsedFlag !== false);
+    const hasAnyUsedSkills = sortedItems.some(item => item.used && item.hasUsedFlag !== false);
 
     return (
-      <div className={`delta-green-skills-grid ${!hasAnyUsedFlags ? 'no-used-column' : ''}`}>
-        {sortedItems.map(item => (
-          <div key={item.id} className="skills-item">
-            {hasAnyUsedFlags && (
-              <div className="skills-col-used">
-                {item.hasUsedFlag !== false ? (
-                  <input
-                    type="checkbox"
-                    checked={item.used}
-                    onChange={() => handleUsedToggle(item, content, setContent, updateSection)}
-                    disabled={!mayEditSheet}
-                  />
-                ) : (
-                  <span></span>
+      <>
+        <div className={`delta-green-skills-grid ${!hasAnyUsedFlags ? 'no-used-column' : ''}`}>
+          {sortedItems.map(item => (
+            <div key={item.id} className="skills-item">
+              {hasAnyUsedFlags && (
+                <div className="skills-col-used">
+                  {item.hasUsedFlag !== false ? (
+                    <input
+                      type="checkbox"
+                      checked={item.used}
+                      onChange={() => handleUsedToggle(item, content, setContent, updateSection)}
+                      disabled={!mayEditSheet}
+                    />
+                  ) : (
+                    <span></span>
+                  )}
+                </div>
+              )}
+              <div className="skills-col-name">{item.name}</div>
+              <div className="skills-col-roll">
+                <span className="roll-display">{item.roll}%</span>
+                {item.roll > 0 && (
+                  <button
+                    className="dice-button"
+                    onClick={() => handleDiceClick(item.name, item.roll, item, content, setContent, updateSection)}
+                    aria-label={intl.formatMessage({ id: 'diceRollModal.title' }) + ` ${item.name}`}
+                    title={intl.formatMessage({ id: 'deltaGreenSkills.rollDice' }, { skillName: item.name })}
+                  >
+                    {intl.formatMessage({ id: 'dice.icon' })}
+                  </button>
                 )}
               </div>
-            )}
-            <div className="skills-col-name">{item.name}</div>
-            <div className="skills-col-roll">
-              <span className="roll-display">{item.roll}%</span>
-              {item.roll > 0 && (
-                <button
-                  className="dice-button"
-                  onClick={() => handleDiceClick(item.name, item.roll, item, content, setContent, updateSection)}
-                  aria-label={intl.formatMessage({ id: 'diceRollModal.title' }) + ` ${item.name}`}
-                  title={intl.formatMessage({ id: 'deltaGreenSkills.rollDice' }, { skillName: item.name })}
-                >
-                  {intl.formatMessage({ id: 'dice.icon' })}
-                </button>
-              )}
             </div>
+          ))}
+        </div>
+        {mayEditSheet && (
+          <div className="post-session-upgrades">
+            <button
+              className="post-session-upgrades-button"
+              onClick={() => handlePostSessionUpgrades(content, setContent, updateSection)}
+              title={intl.formatMessage({ id: 'deltaGreenSkills.postSessionUpgrades.tooltip' })}
+              disabled={!hasAnyUsedSkills}
+            >
+              <FormattedMessage id="deltaGreenSkills.postSessionUpgrades.button" />
+            </button>
           </div>
-        ))}
-      </div>
+        )}
+      </>
     );
   };
 

--- a/ui/src/translations.ts
+++ b/ui/src/translations.ts
@@ -128,6 +128,8 @@ export const messages = {
     'deltaGreenSkills.hasUsedFlag': 'Has used flag',
     'deltaGreenSkills.rollDice': 'Roll dice for {skillName}',
     'deltaGreenSkills.actionFor': 'for {skillName}',
+    'deltaGreenSkills.postSessionUpgrades.button': 'Post-session Upgrades',
+    'deltaGreenSkills.postSessionUpgrades.tooltip': 'Upgrade all used skills (+1%) and clear used flags',
 
     'deltaGreenStats.rollDice': 'Roll dice for {statName}',
     'deltaGreenStats.actionWith': 'with {statName}',


### PR DESCRIPTION
## Summary
- Add Post-session Upgrades button to Delta Green skills section for upgrading used skills
- Improve mobile UX for dice roll modal by changing auto-focus behavior

## Changes Made

### Post-session Upgrades Feature
- **New button**: Always visible when user has edit permissions, disabled when no skills are used
- **Upgrade logic**: Increments all used skills by +1% (max 99%) and clears their used flags
- **Proper layout**: Button centered below skills grid, spans full section width
- **Visual feedback**: Green button with proper hover/active/disabled states

### Mobile UX Improvement
- **Auto-focus change**: Dice roll modal now focuses the roll button instead of action text input
- **Better mobile experience**: Prevents unwanted virtual keyboard popup on mobile devices
- **Faster interaction**: Users can immediately roll dice using Enter/Space keys

### Technical Details
- Added `handlePostSessionUpgrades` function with proper state management
- Updated CSS with grid positioning and button styling
- Added translation keys for button text and tooltip
- Maintained existing multi-column layout for skills

## Test Plan
- [x] Verify button appears when user has edit permissions
- [x] Verify button is disabled when no skills are marked as used
- [x] Test upgrade functionality: skills increment by 1% and used flags clear
- [x] Test mobile dice roll modal: button gets focus, no keyboard popup
- [x] Verify proper layout across different screen sizes
- [x] Run all UI tests - passed
- [x] Deploy to dev environment - successful

🤖 Generated with [Claude Code](https://claude.ai/code)