### PR TITLE
Fix rich text section width to use full section space

### DIFF
--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -455,6 +455,11 @@ button:hover {
   grid-column: 1 / -1;
 }
 
+/* Override section-items grid for rich text content to take full width */
+.section-items .rich-text-content {
+  grid-column: 1 / -1;
+}
+
 .object-item {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Fixed rich text section to use full width instead of only ~1/3 of available space
- Added CSS rule `.section-items .rich-text-content { grid-column: 1 / -1; }` following the existing pattern used by Delta Green sections

## Test plan
- [x] Deployed to development environment 
- [x] Test rich text sections display at full width in character sheets
- [x] Verify no layout regressions in other section types

🤖 Generated with [Claude Code](https://claude.ai/code)