### PR TITLE
Add auto-populate feature for character sheet templates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,11 @@ The application uses a modular section system for character sheets:
 - Environment-specific configs in `terraform/environment/`
 - Reusable modules in `terraform/module/`
 
+The IAC roles and github setup:
+
+- For dev: `AWS_PROFILE=wildsea make iac-dev`
+- For prod: `AWS_PROFILE=wildsea make iac` -- this need the user to enter the name of your github workspace, so ask the user to run this if needed
+
 ## Game Types
 
 The application supports multiple TTRPG systems with specific character types

--- a/Makefile
+++ b/Makefile
@@ -33,12 +33,22 @@ terraform/environment/%/.validate: terraform/environment/%/*.tf terraform-format
 	cd terraform/environment/$* ; terraform validate
 	touch $@
 
+.PHONY: iac-dev
+iac-dev: terraform/environment/aws-dev/.apply
+
+.PHONY: iac
+iac: terraform/environment/aws/.apply
+
 .PHONY: dev
 dev: ui/config/output-dev.json $(GRAPHQL_DEV) terraform-format terraform/environment/aws-dev/.apply terraform/environment/wildsea-dev/.apply ui/.push 
 	@echo URL is "https://$$(jq -r .cdn_domain_name.value $<)/"
 
 terraform/environment/aws-dev/.apply: terraform/environment/aws-dev/*.tf terraform/module/iac-roles/*.tf
 	AUTO_APPROVE=yes ./terraform/environment/aws-dev/deploy.sh $(ACCOUNT_ID) dev
+	touch $@
+
+terraform/environment/aws/.apply: terraform/environment/aws/*.tf terraform/module/iac-roles/*.tf
+	AUTO_APPROVE=yes ./terraform/environment/aws/deploy.sh $(ACCOUNT_ID)
 	touch $@
 
 terraform/environment/wildsea-dev/plan.tfplan: terraform/environment/wildsea-dev/*.tf terraform/module/wildsea/*.tf terraform/environment/wildsea-dev/.terraform $(GRAPHQL_JS)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ To automate:
   * Set up CodeQL to default
   * Set the Protection rules to Any/Any
 
+To set up the IAC roles:
+
+* For dev: `AWS_PROFILE=wildsea make iac-dev`
+* For prod: `AWS_PROFILE=wildsea make iac` -- you will need to enter the name of your github workspace
+
 ## Jumpcloud
 
 To integrate with Jumpcloud as your SAML Provider, get the output User Pool Id

--- a/appsync/graphql.ts
+++ b/appsync/graphql.ts
@@ -22,6 +22,14 @@ export type Scalars = {
   AWSURL: { input: string; output: string; }
 };
 
+export type CharacterTemplateMetadata = {
+  __typename?: 'CharacterTemplateMetadata';
+  displayName: Scalars['String']['output'];
+  gameType: Scalars['String']['output'];
+  language: Scalars['String']['output'];
+  templateName: Scalars['String']['output'];
+};
+
 export type CreateGameInput = {
   description?: InputMaybe<Scalars['String']['input']>;
   gameType: Scalars['String']['input'];
@@ -87,6 +95,7 @@ export type Game = {
   gameDescription?: Maybe<Scalars['String']['output']>;
   gameId: Scalars['ID']['output'];
   gameName: Scalars['String']['output'];
+  gameType: Scalars['String']['output'];
   joinToken?: Maybe<Scalars['String']['output']>;
   playerSheets: Array<PlayerSheet>;
   type: Scalars['String']['output'];
@@ -104,6 +113,17 @@ export type GameSummary = {
   gameType: Scalars['String']['output'];
   type: Scalars['String']['output'];
   updatedAt: Scalars['AWSDateTime']['output'];
+};
+
+export type GetCharacterTemplateInput = {
+  gameType: Scalars['String']['input'];
+  language: Scalars['String']['input'];
+  templateName: Scalars['String']['input'];
+};
+
+export type GetCharacterTemplatesInput = {
+  gameType: Scalars['String']['input'];
+  language: Scalars['String']['input'];
 };
 
 export type GetGameInput = {
@@ -213,8 +233,20 @@ export type PlayerSheetSummary = {
 
 export type Query = {
   __typename?: 'Query';
+  getCharacterTemplate: Array<TemplateSectionData>;
+  getCharacterTemplates: Array<CharacterTemplateMetadata>;
   getGame: Game;
   getGames?: Maybe<Array<PlayerSheetSummary>>;
+};
+
+
+export type QueryGetCharacterTemplateArgs = {
+  input: GetCharacterTemplateInput;
+};
+
+
+export type QueryGetCharacterTemplatesArgs = {
+  input: GetCharacterTemplatesInput;
 };
 
 
@@ -278,6 +310,14 @@ export type SubscriptionUpdatedPlayerArgs = {
 
 export type SubscriptionUpdatedSectionArgs = {
   gameId: Scalars['ID']['input'];
+};
+
+export type TemplateSectionData = {
+  __typename?: 'TemplateSectionData';
+  content: Scalars['AWSJSON']['output'];
+  position: Scalars['Int']['output'];
+  sectionName: Scalars['String']['output'];
+  sectionType: Scalars['String']['output'];
 };
 
 export type UpdateGameInput = {

--- a/appsync/schema.ts
+++ b/appsync/schema.ts
@@ -3,7 +3,7 @@
       export const getGameQuery = `
         query getGame($input: GetGameInput) {
           getGame(input: $input) {
-            gameId gameName gameDescription playerSheets { userId gameId characterName sections { userId gameId sectionId type sectionName sectionType content position createdAt updatedAt deleted } type createdAt updatedAt fireflyUserId } joinToken fireflyUserId createdAt updatedAt type deleted
+            gameId gameName gameType gameDescription playerSheets { userId gameId characterName sections { userId gameId sectionId type sectionName sectionType content position createdAt updatedAt deleted } type createdAt updatedAt fireflyUserId } joinToken fireflyUserId createdAt updatedAt type deleted
           }
         }
       `;
@@ -12,6 +12,22 @@
         query getGames {
           getGames {
             userId gameId gameName gameType gameDescription characterName type createdAt updatedAt deleted
+          }
+        }
+      `;
+    
+      export const getCharacterTemplatesQuery = `
+        query getCharacterTemplates($input: GetCharacterTemplatesInput!) {
+          getCharacterTemplates(input: $input) {
+            templateName displayName gameType language
+          }
+        }
+      `;
+    
+      export const getCharacterTemplateQuery = `
+        query getCharacterTemplate($input: GetCharacterTemplateInput!) {
+          getCharacterTemplate(input: $input) {
+            sectionName sectionType content position
           }
         }
       `;

--- a/graphql/function/getGame/getGame.ts
+++ b/graphql/function/getGame/getGame.ts
@@ -142,6 +142,7 @@ export function makeGameData(data: DataGame, sub: string): Game {
   return {
     gameId: data.gameId,
     gameName: data.gameName,
+    gameType: data.gameType,
     gameDescription: data.gameDescription,
     playerSheets: [],
     joinToken: joinToken,

--- a/graphql/lib/constants/dbPrefixes.ts
+++ b/graphql/lib/constants/dbPrefixes.ts
@@ -3,3 +3,4 @@ export const DDBPrefixSection = "SECTION";
 export const DDBPrefixPlayer = "PLAYER";
 export const DDBPrefixUser = "USER";
 export const DDBPrefixSectionUser = "SECTIONUSER";
+export const DDBPrefixTemplate = "TEMPLATE";

--- a/graphql/lib/constants/entityTypes.ts
+++ b/graphql/lib/constants/entityTypes.ts
@@ -4,3 +4,4 @@ export const TypeSection = "SECTION";
 export const TypeFirefly = "FIREFLY"; // TODO: Rename to TypeGM
 export const TypeShip = "SHIP"; // TODO: Rename to TypeNPC
 export const TypeDiceRoll = "DICEROLL"; // Not stored in database, used only for subscription filtering
+export const TypeTemplate = "TEMPLATE";

--- a/graphql/query/getCharacterTemplate/getCharacterTemplate.ts
+++ b/graphql/query/getCharacterTemplate/getCharacterTemplate.ts
@@ -1,0 +1,39 @@
+import { util, Context, DynamoDBGetItemRequest } from "@aws-appsync/utils";
+import type { GetCharacterTemplateInput } from "../../../appsync/graphql";
+import { DDBPrefixTemplate } from "../../lib/constants/dbPrefixes";
+
+export function request(
+  context: Context<{ input: GetCharacterTemplateInput }>,
+): DynamoDBGetItemRequest {
+  const input = context.arguments.input;
+  const { templateName, gameType, language } = input;
+
+  return {
+    operation: "GetItem",
+    key: util.dynamodb.toMapValues({
+      PK: DDBPrefixTemplate + "#" + gameType + "#" + language,
+      SK: DDBPrefixTemplate + "#" + templateName,
+    }),
+  };
+}
+
+export function response(context: Context): unknown {
+  if (context.error) {
+    util.error(context.error.message, context.error.type);
+  }
+
+  if (!context.result) {
+    util.error("Template not found", "NotFound");
+  }
+
+  // Parse the sections array from the template
+  const sections = JSON.parse(context.result.sections);
+
+  // Parse the content field for each section (it's double-encoded JSON)
+  return sections.map(
+    (section: { content: string; [key: string]: unknown }) => ({
+      ...section,
+      content: JSON.parse(section.content),
+    }),
+  );
+}

--- a/graphql/query/getCharacterTemplates/getCharacterTemplates.ts
+++ b/graphql/query/getCharacterTemplates/getCharacterTemplates.ts
@@ -1,0 +1,40 @@
+import { util, Context, DynamoDBQueryRequest } from "@aws-appsync/utils";
+import type { GetCharacterTemplatesInput } from "../../../appsync/graphql";
+import { DDBPrefixTemplate } from "../../lib/constants/dbPrefixes";
+
+export function request(
+  context: Context<{ input: GetCharacterTemplatesInput }>,
+): DynamoDBQueryRequest {
+  const input = context.arguments.input;
+  const { gameType, language } = input;
+
+  return {
+    operation: "Query",
+    query: {
+      expression: "#PK = :pk",
+      expressionNames: {
+        "#PK": "PK",
+      },
+      expressionValues: util.dynamodb.toMapValues({
+        ":pk": DDBPrefixTemplate + "#" + gameType + "#" + language,
+      }),
+    },
+    projection: {
+      expression: "#templateName, #displayName, #gameType, #language",
+      expressionNames: {
+        "#templateName": "templateName",
+        "#displayName": "displayName",
+        "#gameType": "gameType",
+        "#language": "language",
+      },
+    },
+  };
+}
+
+export function response(context: Context): unknown {
+  if (context.error) {
+    util.error(context.error.message, context.error.type);
+  }
+
+  return context.result.items;
+}

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -33,6 +33,8 @@ type Mutation {
 type Query {
     getGame(input: GetGameInput): Game! @aws_cognito_user_pools
     getGames: [PlayerSheetSummary!] @aws_cognito_user_pools
+    getCharacterTemplates(input: GetCharacterTemplatesInput!): [CharacterTemplateMetadata!]! @aws_cognito_user_pools
+    getCharacterTemplate(input: GetCharacterTemplateInput!): [TemplateSectionData!]! @aws_cognito_user_pools
 }
 
 type Subscription @aws_cognito_user_pools {
@@ -44,6 +46,17 @@ type Subscription @aws_cognito_user_pools {
 
 input GetGameInput {
   gameId: ID!
+}
+
+input GetCharacterTemplatesInput {
+  gameType: String!
+  language: String!
+}
+
+input GetCharacterTemplateInput {
+  templateName: String!
+  gameType: String!
+  language: String!
 }
 
 input CreateGameInput {
@@ -109,6 +122,7 @@ type GameSummary @aws_cognito_user_pools {
 type Game @aws_cognito_user_pools {
   gameId: ID!
   gameName: String!
+  gameType: String!
   gameDescription: String
   playerSheets: [PlayerSheet!]!
   joinToken: String
@@ -202,4 +216,18 @@ type SingleDie @aws_cognito_user_pools {
   type: String!
   size: Int!
   value: Int!
+}
+
+type CharacterTemplateMetadata @aws_cognito_user_pools {
+  templateName: String!
+  displayName: String!
+  gameType: String!
+  language: String!
+}
+
+type TemplateSectionData @aws_cognito_user_pools {
+  sectionName: String!
+  sectionType: String!
+  content: AWSJSON!
+  position: Int!
 }

--- a/graphql/tests/checkGameAccess.test.ts
+++ b/graphql/tests/checkGameAccess.test.ts
@@ -145,6 +145,7 @@ describe("permitted", () => {
   const baseGameData: DataGame = {
     gameId: "game-1",
     gameName: "Test Game",
+    gameType: "wildsea",
     gameDescription: "A test game",
     createdAt: "2023-01-01T00:00:00Z",
     updatedAt: "2023-01-01T00:00:00Z",

--- a/graphql/tests/getGame.test.ts
+++ b/graphql/tests/getGame.test.ts
@@ -112,6 +112,7 @@ describe("response", () => {
           {
             gameId: "game1",
             gameName: "Test Game",
+            gameType: "wildsea",
             gameDescription: "A test game",
             createdAt: "2023-01-01",
             updatedAt: "2023-01-02",
@@ -165,6 +166,7 @@ describe("response", () => {
     expect(result).toEqual({
       gameId: "game1",
       gameName: "Test Game",
+      gameType: "wildsea",
       gameDescription: "A test game",
       playerSheets: [
         {
@@ -217,6 +219,7 @@ describe("response", () => {
           {
             gameId: "game1",
             gameName: "Test Game",
+            gameType: "wildsea",
             gameDescription: "A test game",
             fireflyUserId: "user2",
             createdAt: "2023-01-01",
@@ -270,6 +273,7 @@ describe("response", () => {
     expect(result).toEqual({
       gameId: "game1",
       gameName: "Test Game",
+      gameType: "wildsea",
       gameDescription: "A test game",
       playerSheets: [
         {
@@ -348,6 +352,7 @@ describe("response", () => {
           {
             gameId: "game1",
             gameName: "Test Game",
+            gameType: "wildsea",
             gameDescription: "A test game",
             fireflyUserId: "user1",
             players: [],
@@ -377,6 +382,7 @@ describe("makeGameData", () => {
     const data: DataGame = {
       gameId: "game1",
       gameName: "Test Game",
+      gameType: "wildsea",
       gameDescription: "A test game",
       createdAt: "2023-01-01",
       updatedAt: "2023-01-02",
@@ -391,6 +397,7 @@ describe("makeGameData", () => {
     expect(result).toEqual({
       gameId: "game1",
       gameName: "Test Game",
+      gameType: "wildsea",
       gameDescription: "A test game",
       joinToken: null,
       playerSheets: [],
@@ -405,6 +412,7 @@ describe("makeGameData", () => {
     const data: DataGame = {
       gameId: "game1",
       gameName: "Test Game",
+      gameType: "wildsea",
       gameDescription: "A test game",
       createdAt: "2023-01-01",
       updatedAt: "2023-01-02",
@@ -419,6 +427,7 @@ describe("makeGameData", () => {
     expect(result).toEqual({
       gameId: "game1",
       gameName: "Test Game",
+      gameType: "wildsea",
       gameDescription: "A test game",
       playerSheets: [],
       fireflyUserId: "user1",

--- a/terraform/module/iac-roles/policy.tf
+++ b/terraform/module/iac-roles/policy.tf
@@ -27,6 +27,7 @@ data "aws_iam_policy_document" "ro" {
     actions = [
       "dynamodb:Describe*",
       "dynamodb:List*",
+      "dynamodb:GetItem",
     ]
     resources = [
       "arn:${data.aws_partition.current.id}:dynamodb:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:table/${var.app_name}-${var.environment}"
@@ -191,22 +192,14 @@ data "aws_iam_policy_document" "rw" {
   }
 
   statement {
-    sid    = "DynamodbNoItem"
-    effect = "Deny"
-    actions = [
-      "dynamodb:DeleteItem",
-      "dynamodb:UpdateItem",
-    ]
-    resources = [
-      "arn:${data.aws_partition.current.id}:dynamodb:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:table/${var.app_name}-${var.environment}"
-    ]
-  }
-
-  statement {
     sid = "Dynamodb"
     actions = [
       "dynamodb:Create*",
       "dynamodb:Delete*",
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+      "dynamodb:UpdateItem",
+      "dynamodb:DeleteItem",
       "dynamodb:TagResource",
       "dynamodb:UntagResource",
       "dynamodb:Update*",

--- a/terraform/module/wildsea/templates.tf
+++ b/terraform/module/wildsea/templates.tf
@@ -1,0 +1,417 @@
+# Character templates for auto-populate feature
+resource "aws_dynamodb_table_item" "template_wildsea_basic" {
+  table_name = aws_dynamodb_table.table.name
+  hash_key   = aws_dynamodb_table.table.hash_key
+  range_key  = aws_dynamodb_table.table.range_key
+
+  item = jsonencode({
+    PK = {
+      S = "TEMPLATE#wildsea#en"
+    }
+    SK = {
+      S = "TEMPLATE#Basic Character"
+    }
+    templateName = {
+      S = "Basic Character"
+    }
+    displayName = {
+      S = "Basic Character"
+    }
+    gameType = {
+      S = "wildsea"
+    }
+    language = {
+      S = "en"
+    }
+    type = {
+      S = "TEMPLATE"
+    }
+    sections = {
+      S = jsonencode([
+        {
+          sectionName = "Character Details"
+          sectionType = "KEYVALUE"
+          content = jsonencode({
+            items = [
+              {
+                id          = "name"
+                name        = "Name"
+                description = ""
+              },
+              {
+                id          = "origin"
+                name        = "Origin"
+                description = ""
+              },
+              {
+                id          = "post"
+                name        = "Post"
+                description = ""
+              },
+              {
+                id          = "call"
+                name        = "Call"
+                description = ""
+              }
+            ]
+            showEmpty = true
+          })
+          position = 0
+        },
+        {
+          sectionName = "Edges"
+          sectionType = "TRACKABLE"
+          content = jsonencode({
+            items = [
+              {
+                id          = "iron"
+                name        = "Iron"
+                description = ""
+                current     = 2
+                maximum     = 5
+              },
+              {
+                id          = "teeth"
+                name        = "Teeth"
+                description = ""
+                current     = 2
+                maximum     = 5
+              },
+              {
+                id          = "veils"
+                name        = "Veils"
+                description = ""
+                current     = 2
+                maximum     = 5
+              }
+            ]
+            showEmpty = false
+          })
+          position = 1
+        },
+        {
+          sectionName = "Skills"
+          sectionType = "TRACKABLE"
+          content = jsonencode({
+            items = [
+              {
+                id          = "break"
+                name        = "Break"
+                description = ""
+                current     = 0
+                maximum     = 3
+              },
+              {
+                id          = "delve"
+                name        = "Delve"
+                description = ""
+                current     = 0
+                maximum     = 3
+              },
+              {
+                id          = "hunt"
+                name        = "Hunt"
+                description = ""
+                current     = 0
+                maximum     = 3
+              },
+              {
+                id          = "outwit"
+                name        = "Outwit"
+                description = ""
+                current     = 0
+                maximum     = 3
+              },
+              {
+                id          = "study"
+                name        = "Study"
+                description = ""
+                current     = 0
+                maximum     = 3
+              },
+              {
+                id          = "sway"
+                name        = "Sway"
+                description = ""
+                current     = 0
+                maximum     = 3
+              }
+            ]
+            showEmpty = false
+          })
+          position = 2
+        },
+        {
+          sectionName = "Resources"
+          sectionType = "BURNABLE"
+          content = jsonencode({
+            items = [
+              {
+                id          = "salvage"
+                name        = "Salvage"
+                description = ""
+                length      = 3
+                states      = ["unticked", "unticked", "unticked"]
+              },
+              {
+                id          = "specimens"
+                name        = "Specimens"
+                description = ""
+                length      = 3
+                states      = ["unticked", "unticked", "unticked"]
+              },
+              {
+                id          = "whispers"
+                name        = "Whispers"
+                description = ""
+                length      = 3
+                states      = ["unticked", "unticked", "unticked"]
+              },
+              {
+                id          = "charts"
+                name        = "Charts"
+                description = ""
+                length      = 3
+                states      = ["unticked", "unticked", "unticked"]
+              }
+            ]
+            showEmpty = false
+          })
+          position = 3
+        }
+      ])
+    }
+  })
+}
+
+# Delta Green Basic Character Template
+resource "aws_dynamodb_table_item" "template_deltagreen_basic" {
+  table_name = aws_dynamodb_table.table.name
+  hash_key   = aws_dynamodb_table.table.hash_key
+  range_key  = aws_dynamodb_table.table.range_key
+
+  item = jsonencode({
+    PK = {
+      S = "TEMPLATE#deltaGreen#en"
+    }
+    SK = {
+      S = "TEMPLATE#Basic Agent"
+    }
+    templateName = {
+      S = "Basic Agent"
+    }
+    displayName = {
+      S = "Basic Agent"
+    }
+    gameType = {
+      S = "deltaGreen"
+    }
+    language = {
+      S = "en"
+    }
+    type = {
+      S = "TEMPLATE"
+    }
+    sections = {
+      S = jsonencode([
+        {
+          sectionName = "Agent Details"
+          sectionType = "KEYVALUE"
+          content = jsonencode({
+            items = [
+              {
+                id          = "name"
+                name        = "Name"
+                description = ""
+              },
+              {
+                id          = "profession"
+                name        = "Profession"
+                description = ""
+              },
+              {
+                id          = "employer"
+                name        = "Employer"
+                description = ""
+              },
+              {
+                id          = "nationality"
+                name        = "Nationality"
+                description = ""
+              }
+            ]
+            showEmpty = true
+          })
+          position = 0
+        },
+        {
+          sectionName = "Statistics"
+          sectionType = "DELTAGREENSTATS"
+          content = jsonencode({
+            showEmpty = false
+            items = [
+              {
+                id                     = "stat-str"
+                name                   = "Strength (STR)"
+                description            = ""
+                score                  = 50
+                distinguishingFeatures = ""
+              },
+              {
+                id                     = "stat-con"
+                name                   = "Constitution (CON)"
+                description            = ""
+                score                  = 50
+                distinguishingFeatures = ""
+              },
+              {
+                id                     = "stat-dex"
+                name                   = "Dexterity (DEX)"
+                description            = ""
+                score                  = 50
+                distinguishingFeatures = ""
+              },
+              {
+                id                     = "stat-int"
+                name                   = "Intelligence (INT)"
+                description            = ""
+                score                  = 50
+                distinguishingFeatures = ""
+              },
+              {
+                id                     = "stat-pow"
+                name                   = "Power (POW)"
+                description            = ""
+                score                  = 50
+                distinguishingFeatures = ""
+              },
+              {
+                id                     = "stat-cha"
+                name                   = "Charisma (CHA)"
+                description            = ""
+                score                  = 50
+                distinguishingFeatures = ""
+              }
+            ]
+          })
+          position = 1
+        },
+        {
+          sectionName = "Derived Attributes"
+          sectionType = "DELTAGREENDERED"
+          content = jsonencode({
+            showEmpty = false
+            items = [
+              {
+                id            = "hp-item"
+                name          = "Hit Points (HP)"
+                description   = ""
+                attributeType = "HP"
+                current       = 10
+                maximum       = 10
+              },
+              {
+                id            = "wp-item"
+                name          = "Willpower Points (WP)"
+                description   = ""
+                attributeType = "WP"
+                current       = 10
+                maximum       = 10
+              },
+              {
+                id            = "san-item"
+                name          = "Sanity Points (SAN)"
+                description   = ""
+                attributeType = "SAN"
+                current       = 50
+                maximum       = 50
+              },
+              {
+                id            = "bp-item"
+                name          = "Breaking Point (BP)"
+                description   = ""
+                attributeType = "BP"
+                current       = 40
+              }
+            ]
+          })
+          position = 2
+        },
+        {
+          sectionName = "Skills"
+          sectionType = "DELTAGREENSKILLS"
+          content = jsonencode({
+            showEmpty = false
+            items = [
+              {
+                id          = "skill-alertness"
+                name        = "Alertness"
+                description = ""
+                roll        = 20
+                used        = false
+                hasUsedFlag = true
+              },
+              {
+                id          = "skill-athletics"
+                name        = "Athletics"
+                description = ""
+                roll        = 30
+                used        = false
+                hasUsedFlag = true
+              },
+              {
+                id          = "skill-dodge"
+                name        = "Dodge"
+                description = ""
+                roll        = 30
+                used        = false
+                hasUsedFlag = true
+              },
+              {
+                id          = "skill-firearms"
+                name        = "Firearms"
+                description = ""
+                roll        = 20
+                used        = false
+                hasUsedFlag = true
+              },
+              {
+                id          = "skill-first-aid"
+                name        = "First Aid"
+                description = ""
+                roll        = 10
+                used        = false
+                hasUsedFlag = true
+              },
+              {
+                id          = "skill-persuade"
+                name        = "Persuade"
+                description = ""
+                roll        = 20
+                used        = false
+                hasUsedFlag = true
+              },
+              {
+                id          = "skill-search"
+                name        = "Search"
+                description = ""
+                roll        = 20
+                used        = false
+                hasUsedFlag = true
+              },
+              {
+                id          = "skill-stealth"
+                name        = "Stealth"
+                description = ""
+                roll        = 10
+                used        = false
+                hasUsedFlag = true
+              }
+            ]
+          })
+          position = 3
+        }
+      ])
+    }
+  })
+}

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -2167,3 +2167,83 @@ button:hover {
     margin-left: 4px;
   }
 }
+
+/* Auto-populate section styling */
+.auto-populate-section {
+  margin-bottom: 20px;
+  padding: 15px;
+  border: 2px solid #007bff;
+  border-radius: 6px;
+  background-color: #f8f9fa;
+  box-shadow: 0 2px 4px rgba(0, 123, 255, 0.1);
+}
+
+.auto-populate-section h3 {
+  margin-top: 0;
+  margin-bottom: 10px;
+  color: #007bff;
+  display: flex;
+  align-items: center;
+  font-weight: 600;
+}
+
+.auto-populate-section h3::before {
+  content: "⚡";
+  margin-right: 8px;
+  font-size: 1.2em;
+}
+
+.auto-populate-section p {
+  margin-bottom: 15px;
+  color: #6c757d;
+  font-style: italic;
+}
+
+.auto-populate-form {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.auto-populate-form select {
+  flex: 1;
+  min-width: 200px;
+  padding: 8px 12px;
+  border: 1px solid #ced4da;
+  border-radius: 4px;
+  background-color: white;
+  font-size: 14px;
+}
+
+.auto-populate-form button {
+  padding: 8px 16px;
+  background-color: #007bff;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.auto-populate-form button:hover:not(:disabled) {
+  background-color: #0056b3;
+}
+
+.auto-populate-form button:disabled {
+  background-color: #6c757d;
+  cursor: not-allowed;
+}
+
+@media screen and (width <= 768px) {
+  .auto-populate-form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  
+  .auto-populate-form select {
+    min-width: unset;
+    margin-bottom: 10px;
+  }
+}

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -2175,7 +2175,7 @@ button:hover {
   border: 2px solid #007bff;
   border-radius: 6px;
   background-color: #f8f9fa;
-  box-shadow: 0 2px 4px rgba(0, 123, 255, 0.1);
+  box-shadow: 0 2px 4px rgb(0 123 255 / 10%);
 }
 
 .auto-populate-section h3 {

--- a/ui/src/playerSheetTab.tsx
+++ b/ui/src/playerSheetTab.tsx
@@ -13,6 +13,7 @@ import { DragDropContext, Droppable, Draggable, DroppableProvided, DraggableProv
 import Modal from 'react-modal';
 import { DeletePlayerModal } from './deletePlayer';
 import { DeleteGameModal } from './deleteGame';
+import { SectionAutoPopulate } from './sectionAutoPopulate';
 
 const reorderSections = (sections: SheetSection[], startIndex: number, endIndex: number) => {
   const result = Array.from(sections);
@@ -257,6 +258,18 @@ export const PlayerSheetTab: React.FC<{ sheet: PlayerSheet, userSubject: string,
         <div className="read-only-sections">
           {renderSections(sheet.sections, false)}
         </div>
+      )}
+
+      {mayEditSheet && sheet.sections.length === 0 && (
+        <SectionAutoPopulate
+          gameType={game.gameType || 'wildsea'}
+          gameId={sheet.gameId}
+          userId={sheet.userId}
+          onSectionsAdded={() => {
+            // The sections will be updated automatically via GraphQL subscriptions
+            // so we don't need to do anything here
+          }}
+        />
       )}
 
       {mayEditSheet && !showNewSection && (

--- a/ui/src/sectionAutoPopulate.tsx
+++ b/ui/src/sectionAutoPopulate.tsx
@@ -1,0 +1,154 @@
+import React, { useState, useEffect } from 'react';
+import { generateClient } from 'aws-amplify/api';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { CharacterTemplateMetadata, TemplateSectionData, CreateSectionInput } from "../../appsync/graphql";
+import { getCharacterTemplatesQuery, getCharacterTemplateQuery, createSectionMutation } from "../../appsync/schema";
+import { GraphQLResult } from "@aws-amplify/api-graphql";
+import { useToast } from './notificationToast';
+
+interface AutoPopulateProps {
+  gameType: string;
+  gameId: string;
+  userId: string;
+  onSectionsAdded: () => void;
+}
+
+export const SectionAutoPopulate: React.FC<AutoPopulateProps> = ({
+  gameType,
+  gameId,
+  userId,
+  onSectionsAdded,
+}) => {
+  const [templates, setTemplates] = useState<CharacterTemplateMetadata[]>([]);
+  const [selectedTemplate, setSelectedTemplate] = useState<string>('');
+  const [loading, setLoading] = useState(false);
+  const [loadingTemplates, setLoadingTemplates] = useState(true);
+  const intl = useIntl();
+  const toast = useToast();
+
+  useEffect(() => {
+    fetchTemplates();
+  }, [gameType]);
+
+  const fetchTemplates = async () => {
+    try {
+      const client = generateClient();
+      const response = await client.graphql({
+        query: getCharacterTemplatesQuery,
+        variables: {
+          input: {
+            gameType: gameType,
+            language: intl.locale || 'en',
+          },
+        },
+      }) as GraphQLResult<{ getCharacterTemplates: CharacterTemplateMetadata[] }>;
+
+      setTemplates(response.data?.getCharacterTemplates || []);
+    } catch (error) {
+      console.error('Error fetching templates:', error);
+      toast.addToast(intl.formatMessage({ id: "autoPopulate.fetchTemplatesError" }), 'error');
+    } finally {
+      setLoadingTemplates(false);
+    }
+  };
+
+  const handleAutoPopulate = async () => {
+    if (!selectedTemplate) return;
+
+    setLoading(true);
+    try {
+      const client = generateClient();
+      
+      // Fetch template sections
+      const templateResponse = await client.graphql({
+        query: getCharacterTemplateQuery,
+        variables: {
+          input: {
+            templateName: selectedTemplate,
+            gameType: gameType,
+            language: intl.locale || 'en',
+          },
+        },
+      }) as GraphQLResult<{ getCharacterTemplate: TemplateSectionData[] }>;
+
+      const templateSections = templateResponse.data?.getCharacterTemplate || [];
+
+      // Create all sections in order
+      for (const section of templateSections) {
+        const input: CreateSectionInput = {
+          userId: userId,
+          gameId: gameId,
+          sectionName: section.sectionName,
+          sectionType: section.sectionType,
+          content: section.content,
+          position: section.position,
+        };
+
+        await client.graphql({
+          query: createSectionMutation,
+          variables: { input },
+        });
+      }
+
+      toast.addToast(intl.formatMessage({ id: "autoPopulate.success" }), 'success');
+      onSectionsAdded();
+    } catch (error) {
+      console.error('Error auto-populating character:', error);
+      toast.addToast(intl.formatMessage({ id: "autoPopulate.error" }), 'error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (loadingTemplates) {
+    return (
+      <div className="auto-populate-section">
+        <FormattedMessage id="autoPopulate.loadingTemplates" />
+      </div>
+    );
+  }
+
+  if (templates.length === 0) {
+    return (
+      <div className="auto-populate-section">
+        <h3><FormattedMessage id="autoPopulate.title" /></h3>
+        <p><FormattedMessage id="autoPopulate.noTemplates" /></p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="auto-populate-section">
+      <h3><FormattedMessage id="autoPopulate.title" /></h3>
+      <p><FormattedMessage id="autoPopulate.description" /></p>
+      
+      <div className="auto-populate-form">
+        <select
+          value={selectedTemplate}
+          onChange={(e) => setSelectedTemplate(e.target.value)}
+          disabled={loading}
+        >
+          <option value="">
+            {intl.formatMessage({ id: "autoPopulate.selectTemplate" })}
+          </option>
+          {templates.map((template) => (
+            <option key={template.templateName} value={template.templateName}>
+              {template.displayName}
+            </option>
+          ))}
+        </select>
+        
+        <button
+          onClick={handleAutoPopulate}
+          disabled={!selectedTemplate || loading}
+        >
+          {loading ? (
+            <FormattedMessage id="autoPopulate.applying" />
+          ) : (
+            <FormattedMessage id="autoPopulate.apply" />
+          )}
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/ui/src/sectionDeltaGreenDerived.tsx
+++ b/ui/src/sectionDeltaGreenDerived.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { BaseSection, BaseSectionContent, BaseSectionItem, SectionDefinition } from './baseSection';
 import { SheetSection } from "../../appsync/graphql";
 import { useIntl, FormattedMessage } from 'react-intl';
@@ -67,7 +67,7 @@ export const SectionDeltaGreenDerived: React.FC<SectionDefinition> = (props) => 
     mayEditSheet: boolean,
     setContent: React.Dispatch<React.SetStateAction<SectionTypeDeltaGreenDerived>>,
     updateSection: (updatedSection: Partial<SheetSection>) => Promise<void>,
-    isEditing: boolean,
+    _isEditing: boolean,
   ) => {
     const stats = getStatsFromDataAttributes();
     const derivedCalcs = stats ? calculateDerivedAttributes(stats) : null;
@@ -86,7 +86,7 @@ export const SectionDeltaGreenDerived: React.FC<SectionDefinition> = (props) => 
         </div>
         {content.items.map(item => {
           const calc = derivedCalcs?.[item.attributeType];
-          const displayMax = calc?.max ?? item.maximum;
+          const displayMax = calc && 'max' in calc ? calc.max : item.maximum;
           const displayCurrent = item.attributeType === 'BP' ? (calc?.current ?? item.current) : item.current;
           const isDisorderRow = hasDisorder && (item.attributeType === 'SAN' || item.attributeType === 'BP');
           
@@ -141,7 +141,7 @@ export const SectionDeltaGreenDerived: React.FC<SectionDefinition> = (props) => 
     );
   };
 
-  const renderEditForm = (content: SectionTypeDeltaGreenDerived, setContent: React.Dispatch<React.SetStateAction<SectionTypeDeltaGreenDerived>>) => {
+  const renderEditForm = (_content: SectionTypeDeltaGreenDerived, _setContent: React.Dispatch<React.SetStateAction<SectionTypeDeltaGreenDerived>>) => {
     return (
       <div className="delta-green-derived-edit">
         <p><FormattedMessage id="deltaGreenDerived.editNote" /></p>
@@ -152,7 +152,7 @@ export const SectionDeltaGreenDerived: React.FC<SectionDefinition> = (props) => 
   return <BaseSection<DeltaGreenDerivedItem> {...props} renderItems={renderItems} renderEditForm={renderEditForm} />;
 };
 
-export const createDefaultDeltaGreenDerivedContent = (sheet?: any): SectionTypeDeltaGreenDerived => {
+export const createDefaultDeltaGreenDerivedContent = (_sheet?: any): SectionTypeDeltaGreenDerived => {
   // Try to get stats from data attributes (will be null on initial creation)
   const stats = getStatsFromDataAttributes();
   const derivedCalcs = stats ? calculateDerivedAttributes(stats) : null;

--- a/ui/src/translations.ts
+++ b/ui/src/translations.ts
@@ -178,6 +178,18 @@ export const messages = {
     'diceRollModal.rollHelp': 'Roll a d100 against the target number',
     'diceRollModal.result': 'Roll Result',
 
+    // Auto-populate translations
+    'autoPopulate.title': 'Auto-Populate Character',
+    'autoPopulate.description': 'Choose a pre-made character template to quickly set up your character sheet.',
+    'autoPopulate.selectTemplate': 'Select a character template...',
+    'autoPopulate.apply': 'Apply Template',
+    'autoPopulate.applying': 'Applying template...',
+    'autoPopulate.success': 'Character template applied successfully!',
+    'autoPopulate.error': 'Error applying character template',
+    'autoPopulate.fetchTemplatesError': 'Error loading character templates',
+    'autoPopulate.loadingTemplates': 'Loading templates...',
+    'autoPopulate.noTemplates': 'No character templates are available for this game type.',
+
     // Common section translations
     'sectionObject.updateError': 'Failed to update the section',
     'sectionObject.addItem': '➕',


### PR DESCRIPTION
## Summary
• Add auto-populate feature that allows players to quickly set up character sheets using pre-defined templates
• Templates are game-type and language specific (Wildsea and Delta Green supported)
• Feature appears only when character sheet is empty and provides dropdown selection

## Backend Implementation
• **GraphQL Schema**: Added `getCharacterTemplates` and `getCharacterTemplate` queries
• **Database**: New TEMPLATE entity type using PK/SK pattern: `TEMPLATE#{gameType}#{language}` / `TEMPLATE#{templateName}`
• **Resolvers**: Lightweight metadata fetching + full template content retrieval with JSON parsing
• **IAM**: Updated permissions to allow DynamoDB template operations

## Frontend Implementation
• **Component**: `SectionAutoPopulate` with game-type filtering and template selection
• **Styling**: Blue-themed section with lightning bolt icon, responsive design
• **Integration**: Seamless integration with existing section registry and translation system
• **UX**: Shows helpful message when no templates available, loading states, error handling

## Infrastructure
• **Terraform**: Repeatable template creation via `terraform/module/wildsea/templates.tf`
• **Sample Data**: Wildsea "Basic Character" and Delta Green "Basic Agent" templates
• **Permissions**: Updated IAM roles for template management

## Test Plan
- [x] Empty character sheet shows auto-populate section
- [x] Template dropdown filters by game type (Wildsea/Delta Green)
- [x] Template application creates sections in correct order with proper structure
- [x] Responsive design works on mobile devices
- [x] Error handling for missing templates and network issues
- [x] TypeScript compliance with no IDE warnings

🤖 Generated with [Claude Code](https://claude.ai/code)