### PR TITLE
Fix Delta Green derived attributes max value validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ required are in the Makefile.
 AWS_PROFILE=<profile> make ui-local
 
 # Deploy development environment
+# This does EVERYTHING required to fully update the dev environment, including terraform
 AWS_PROFILE=<profile> make dev
 ```
 

--- a/terraform/module/wildsea/templates.tf
+++ b/terraform/module/wildsea/templates.tf
@@ -318,7 +318,6 @@ resource "aws_dynamodb_table_item" "template_deltagreen_basic" {
                 description   = ""
                 attributeType = "HP"
                 current       = 10
-                maximum       = 10
               },
               {
                 id            = "wp-item"
@@ -326,7 +325,6 @@ resource "aws_dynamodb_table_item" "template_deltagreen_basic" {
                 description   = ""
                 attributeType = "WP"
                 current       = 10
-                maximum       = 10
               },
               {
                 id            = "san-item"
@@ -334,7 +332,6 @@ resource "aws_dynamodb_table_item" "template_deltagreen_basic" {
                 description   = ""
                 attributeType = "SAN"
                 current       = 50
-                maximum       = 50
               },
               {
                 id            = "bp-item"


### PR DESCRIPTION
## Summary
- Fixed Delta Green derived attributes to properly respect current calculated maximums instead of original stored values
- Removed redundant `maximum` field from data structure since values are always calculated from stats
- Added automatic clamping when stats decrease, lowering maximums below current values
- Added sync mechanism to ensure maximum changes propagate to all players/devices
- Restricted auto-updates to authorized players only to prevent permission errors

## Test plan
- [x] Test increasing stats - current values can now be set up to new higher maximums
- [x] Test decreasing stats - current values automatically clamp to new lower maximums  
- [x] Test multi-player scenarios - maximum changes sync properly without permission errors
- [x] Verify UI validation matches displayed maximums

🤖 Generated with [Claude Code](https://claude.ai/code)