### PR TITLE
Update Delta Green skills to use standard SectionEditForm

### DIFF
--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -1418,21 +1418,6 @@
   padding: 0;
 }
 
-.delta-green-skills-items-edit {
-  margin-top: 10px;
-}
-
-.delta-green-skills-item-edit {
-  display: grid;
-  grid-template-columns: 2fr 1fr 1fr auto;
-  gap: 10px;
-  align-items: center;
-  margin-bottom: 10px;
-  padding: 10px;
-  border: 1px solid var(--color-border);
-  border-radius: 4px;
-  background-color: var(--color-surface-light);
-}
 
 .roll-input-with-controls {
   display: flex;
@@ -1446,26 +1431,6 @@
   justify-content: center;
 }
 
-.delta-green-skills-item-edit input[type="text"] {
-  padding: 6px;
-  border: 1px solid var(--color-border);
-  border-radius: 3px;
-}
-
-.delta-green-skills-item-edit input[type="number"] {
-  padding: 6px;
-  border: 1px solid var(--color-border);
-  border-radius: 3px;
-  text-align: center;
-}
-
-.delta-green-skills-item-edit label {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  font-size: 14px;
-  white-space: nowrap;
-}
 
 
 .show-empty-toggle {
@@ -1510,10 +1475,6 @@
     font-size: 9px;
   }
   
-  .delta-green-skills-item-edit {
-    grid-template-columns: 1fr;
-    gap: 5px;
-  }
 }
 
 /* Post-session upgrades button styling */

--- a/ui/src/sectionDeltaGreenSkills.tsx
+++ b/ui/src/sectionDeltaGreenSkills.tsx
@@ -4,6 +4,7 @@ import { SheetSection } from "../../appsync/graphql";
 import { useIntl, FormattedMessage } from 'react-intl';
 import { v4 as uuidv4 } from 'uuid';
 import { DiceRollModal } from './components/DiceRollModal';
+import { SectionEditForm } from './components/SectionEditForm';
 import { Grades } from "../../graphql/lib/constants/rollTypes";
 
 // Color scaling function for skill proficiency (0-99 scale)
@@ -255,19 +256,11 @@ export const SectionDeltaGreenSkills: React.FC<SectionDefinition> = (props) => {
     };
 
     return (
-      <div className="delta-green-skills-items-edit">
-        <div className="show-empty-toggle">
-          <label>
-            <input
-              type="checkbox"
-              checked={content.showEmpty}
-              onChange={() => setContent({ ...content, showEmpty: !content.showEmpty })}
-            />
-            <FormattedMessage id="sectionObject.showEmpty" />
-          </label>
-        </div>
-        {content.items.map((item, index) => (
-          <div key={item.id} className="delta-green-skills-item-edit">
+      <SectionEditForm
+        content={content}
+        setContent={setContent}
+        renderItemEdit={(item, index) => (
+          <>
             <input
               type="text"
               value={item.name}
@@ -326,15 +319,11 @@ export const SectionDeltaGreenSkills: React.FC<SectionDefinition> = (props) => {
               />
               <FormattedMessage id="deltaGreenSkills.hasUsedFlag" />
             </label>
-            <button onClick={() => handleRemoveItem(index)} className="btn-edit-form">
-              <FormattedMessage id="sectionObject.removeItem" />
-            </button>
-          </div>
-        ))}
-        <button onClick={handleAddItem} className="btn-edit-form">
-          <FormattedMessage id="sectionObject.addItem" />
-        </button>
-      </div>
+          </>
+        )}
+        addItem={handleAddItem}
+        removeItem={handleRemoveItem}
+      />
     );
   };
 


### PR DESCRIPTION
## Summary
- Updated Delta Green skills section to use the standard `SectionEditForm` component instead of its custom edit form
- Maintained all existing functionality while achieving visual consistency with other section types
- Reduced code complexity and removed redundant CSS

## Changes Made
- **Replaced Custom Edit Form**: Migrated from custom edit form implementation to standard `SectionEditForm`
- **Preserved Functionality**: All existing features work exactly as before:
  - Skill name text input
  - Roll value number input with +/-10 and +/-1 adjustment buttons  
  - "Has used flag" checkbox toggle
  - Add/remove skill functionality
  - Show empty skills toggle
- **CSS Cleanup**: Removed unused CSS classes (`.delta-green-skills-items-edit`, `.delta-green-skills-item-edit`)
- **Code Reduction**: Eliminated ~70 lines of custom edit form code while maintaining all features

## Benefits
- **Visual Consistency**: Delta Green skills now have the same improved styling as other section edit forms
- **Maintainability**: All section edit forms now use the same base component
- **Code Simplification**: Reduced duplication and complexity
- **Future-Proof**: Benefits from any improvements made to the standard edit form

## Test Plan
- [x] UI tests pass
- [x] Full development deployment successful
- [x] All Delta Green skills functionality preserved:
  - [x] Skill editing works correctly
  - [x] Roll adjustment buttons (+/-10, +/-1) function properly
  - [x] Used flag checkbox toggles correctly
  - [x] Add/remove skills works as expected
  - [x] Show empty toggle functions correctly
- [x] Visual consistency verified with other section types

The Delta Green skills section now uses the improved standard edit form while retaining all its specialized controls.

🤖 Generated with [Claude Code](https://claude.ai/code)