### PR TITLE
Update Delta Green statistics to use standard edit form and clean up unused CSS

### DIFF
--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -633,10 +633,6 @@
   margin: 0 0.5rem;
 }
 
-/* Legacy class for backwards compatibility */
-.show-zeros-toggle {
-  margin-top: 1rem;
-}
 
 .react-tooltip {
   max-width: 250px; /* Adjust to the width you prefer */

--- a/ui/src/sectionDeltaGreenStats.tsx
+++ b/ui/src/sectionDeltaGreenStats.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import { BaseSection, BaseSectionContent, BaseSectionItem, SectionDefinition } from './baseSection';
 import { SheetSection } from "../../appsync/graphql";
-import { useIntl, FormattedMessage } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { v4 as uuidv4 } from 'uuid';
 import { DiceRollModal } from './components/DiceRollModal';
+import { SectionEditForm } from './components/SectionEditForm';
 
 interface DeltaGreenStatItem extends BaseSectionItem {
   score: number;
@@ -109,9 +110,11 @@ export const SectionDeltaGreenStats: React.FC<SectionDefinition> = (props) => {
     };
 
     return (
-      <div className="delta-green-stats-items-edit">
-        {content.items.map((item, index) => (
-          <div key={item.id} className="delta-green-stats-item-edit">
+      <SectionEditForm
+        content={content}
+        setContent={setContent}
+        renderItemEdit={(item, index) => (
+          <>
             <input
               type="text"
               value={item.name}
@@ -133,15 +136,11 @@ export const SectionDeltaGreenStats: React.FC<SectionDefinition> = (props) => {
               placeholder={intl.formatMessage({ id: "deltaGreenStats.distinguishingFeatures" })}
               maxLength={40}
             />
-            <button onClick={() => handleRemoveItem(index)} className="btn-edit-form">
-              <FormattedMessage id="sectionObject.removeItem" />
-            </button>
-          </div>
-        ))}
-        <button onClick={handleAddItem} className="btn-edit-form">
-          <FormattedMessage id="sectionObject.addItem" />
-        </button>
-      </div>
+          </>
+        )}
+        addItem={handleAddItem}
+        removeItem={handleRemoveItem}
+      />
     );
   };
 


### PR DESCRIPTION
## Summary
- Migrate Delta Green statistics to use `SectionEditForm` while preserving all functionality
- Clean up unused CSS class `.show-zeros-toggle` 
- Remove unused import from Delta Green stats component

## Test plan
- [x] Verify Delta Green statistics edit form works correctly with standard layout
- [x] Confirm all fields are preserved (statistic name, score 0-18, distinguishing features with maxLength 40)
- [x] Test that CSS cleanup doesn't break any existing functionality
- [x] Run tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)