### PR TITLE
Fix TypeScript warnings in section components

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,22 @@
 {
     "cSpell.words": [
+        "allgames",
         "amplifyconfig",
         "amplifyconfiguration",
         "DELTAGREENDERED",
+        "deltagreenskills",
         "DELTAGREENSTATS",
         "DICEROLL",
+        "gameslist",
+        "HUMINT",
+        "joingame",
         "KEYVALUE",
+        "newgame",
+        "pangea",
         "SECTIONUSER",
+        "tippyjs",
+        "unticked",
+        "uuidv",
         "wildsea"
     ]
 }

--- a/ui/src/sectionBurnable.tsx
+++ b/ui/src/sectionBurnable.tsx
@@ -53,7 +53,7 @@ export const SectionBurnable: React.FC<SectionDefinition> = (props) => {
             content: SectionTypeBurnable,
             setContent: React.Dispatch<React.SetStateAction<SectionTypeBurnable>>,
             updateSection: (updatedSection: Partial<SheetSection>) => Promise<void>,
-    isEditing: boolean,
+    _isEditing: boolean,
         ) => {
         const newItems = [...content.items];
         const itemIndex = newItems.findIndex(i => i.id === item.id);
@@ -86,7 +86,7 @@ export const SectionBurnable: React.FC<SectionDefinition> = (props) => {
             mayEditSheet: boolean,
             setContent: React.Dispatch<React.SetStateAction<SectionTypeBurnable>>,
             updateSection: (updatedSection: Partial<SheetSection>) => Promise<void>,
-    isEditing: boolean,
+    _isEditing: boolean,
         ) => {
         return content.items
         .filter(item => content.showEmpty || item.states.some(state => state !== 'unticked'))
@@ -106,7 +106,7 @@ export const SectionBurnable: React.FC<SectionDefinition> = (props) => {
                         <BurnCheckbox
                             key={`${item.id}-${index}`}
                             state={state}
-                            onClick={() => handleStateChange(item, index, content, setContent, updateSection)}
+                            onClick={() => handleStateChange(item, index, content, setContent, updateSection, _isEditing)}
                             disabled={!mayEditSheet}
                         />
                     ))}

--- a/ui/src/sectionDeltaGreenSkills.tsx
+++ b/ui/src/sectionDeltaGreenSkills.tsx
@@ -109,7 +109,7 @@ export const SectionDeltaGreenSkills: React.FC<SectionDefinition> = (props) => {
     skillValue: number, 
     item: DeltaGreenSkillItem,
     content: SectionTypeDeltaGreenSkills,
-    setContent: React.Dispatch<React.SetStateAction<SectionTypeDeltaGreenSkills>>,
+    _setContent: React.Dispatch<React.SetStateAction<SectionTypeDeltaGreenSkills>>,
     updateSection: (updatedSection: Partial<SheetSection>) => Promise<void>
   ) => {
     const actionText = intl.formatMessage({ id: 'deltaGreenSkills.actionFor' }, { skillName });
@@ -164,7 +164,7 @@ export const SectionDeltaGreenSkills: React.FC<SectionDefinition> = (props) => {
     mayEditSheet: boolean,
     setContent: React.Dispatch<React.SetStateAction<SectionTypeDeltaGreenSkills>>,
     updateSection: (updatedSection: Partial<SheetSection>) => Promise<void>,
-    isEditing: boolean,
+    _isEditing: boolean,
   ) => {
     const filteredItems = content.showEmpty 
       ? content.items 

--- a/ui/src/sectionDeltaGreenStats.tsx
+++ b/ui/src/sectionDeltaGreenStats.tsx
@@ -35,10 +35,10 @@ export const SectionDeltaGreenStats: React.FC<SectionDefinition> = (props) => {
 
   const renderItems = (
         content: SectionTypeDeltaGreenStats,
-        mayEditSheet: boolean,
-        setContent: React.Dispatch<React.SetStateAction<SectionTypeDeltaGreenStats>>,
-        updateSection: (updatedSection: Partial<SheetSection>) => Promise<void>,
-        isEditing: boolean,
+        _mayEditSheet: boolean,
+        _setContent: React.Dispatch<React.SetStateAction<SectionTypeDeltaGreenStats>>,
+        _updateSection: (updatedSection: Partial<SheetSection>) => Promise<void>,
+        _isEditing: boolean,
     ) => {
     // Create data attributes from current stats for derived attributes to read
     const statsDataAttributes: { [key: string]: number } = {};

--- a/ui/src/sectionKeyValue.tsx
+++ b/ui/src/sectionKeyValue.tsx
@@ -21,7 +21,7 @@ export const SectionKeyValue: React.FC<SectionDefinition> = (props) => {
         content: SectionTypeKeyValue,
         setContent: React.Dispatch<React.SetStateAction<SectionTypeKeyValue>>,
         updateSection: (updatedSection: Partial<SheetSection>) => Promise<void>,
-    isEditing: boolean,
+    _isEditing: boolean,
     ) => {
     const newItems = [...content.items];
     const itemIndex = newItems.findIndex(i => i.id === item.id);
@@ -50,7 +50,7 @@ export const SectionKeyValue: React.FC<SectionDefinition> = (props) => {
             <input
               type="text"
               value={item.value}
-              onChange={(e) => handleValueChange(item, e.target.value, content, setContent, updateSection)}
+              onChange={(e) => handleValueChange(item, e.target.value, content, setContent, updateSection, isEditing)}
               disabled={!mayEditSheet}
             />
           )}

--- a/ui/src/sectionTrackable.tsx
+++ b/ui/src/sectionTrackable.tsx
@@ -41,7 +41,7 @@ export const SectionTrackable: React.FC<SectionDefinition> = (props) => {
       content: SectionTypeTrackable,
       setContent: React.Dispatch<React.SetStateAction<SectionTypeTrackable>>,
       updateSection: (updatedSection: Partial<SheetSection>) => Promise<void>,
-    isEditing: boolean,
+    _isEditing: boolean,
     ) => {
     const newItems = [...content.items];
     const itemIndex = newItems.findIndex(i => i.id === item.id);
@@ -78,7 +78,7 @@ export const SectionTrackable: React.FC<SectionDefinition> = (props) => {
                 <TickCheckbox
                   key={`${item.id}-${index}`}
                   state={index < item.ticked ? 'ticked' : 'unticked'}
-                  onClick={() => handleTickClick(item, index, content, setContent, updateSection)}
+                  onClick={() => handleTickClick(item, index, content, setContent, updateSection, isEditing)}
                   disabled={!mayEditSheet}
                 />
               ))}


### PR DESCRIPTION
## Summary
- Fix TypeScript warnings about unused parameters and missing function arguments in section components
- Add missing `isEditing` parameter to function calls in sectionBurnable, sectionKeyValue, and sectionTrackable
- Prefix truly unused parameters with underscore (`_isEditing`, `_setContent`, etc.) to indicate intentional non-use
- Maintain BaseSection interface compliance while eliminating all TypeScript warnings

## Technical Details
Section components must implement `renderItems` with a 6-parameter signature as required by BaseSection, even when some parameters aren't used. This PR ensures:
- Function calls include all required parameters
- Unused parameters are clearly marked with underscore prefix
- Interface contracts are maintained across all section types

## Test Plan
- [x] All TypeScript warnings resolved in Skills and Stats sections
- [x] UI tests pass
- [x] Deployed to dev environment successfully
- [x] No functional changes to section behavior

🤖 Generated with [Claude Code](https://claude.ai/code)