### PR TITLE
Fix controlled component warnings in section inputs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,22 +1,37 @@
 {
     "cSpell.words": [
+        "accountid",
         "allgames",
+        "amazoncognito",
         "amplifyconfig",
         "amplifyconfiguration",
+        "authorised",
+        "Codacy",
         "DELTAGREENDERED",
         "deltagreenskills",
         "DELTAGREENSTATS",
         "DICEROLL",
+        "DNSSEC",
+        "firstname",
         "gameslist",
+        "gpgsign",
         "HUMINT",
+        "idpresponse",
         "joingame",
+        "Jumpcloud",
         "KEYVALUE",
+        "lastname",
         "newgame",
         "pangea",
         "SECTIONUSER",
+        "signingkey",
+        "TERRAFOM",
+        "tfstate",
+        "tfvars",
         "tippyjs",
         "unticked",
         "uuidv",
-        "wildsea"
+        "wildsea",
+        "YOURDOMAIN"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ If you do not set the secret, then Cognito will be used as the identity source.
   * Back to dashboard
   * Go to "Credentials", and "Create Credentials", then "OAuth Client ID"
   * Name it "wildsea" or "wildsea-dev"
-  * For the autorised javascript origins, add your cognito url available from the app integration page of the user pool - e.g. <https://yourDomainPrefix.auth.region.amazoncognito.com> (If it is not set up yet, add a dummy value and come back and change this later)
+  * For the authorised javascript origins, add your cognito url available from the app integration page of the user pool - e.g. <https://yourDomainPrefix.auth.region.amazoncognito.com> (If it is not set up yet, add a dummy value and come back and change this later)
   * Set the authorised redirect URIs to the same URL, with `/oauth2/idpresponse` added onto the end
   * Create
   * For dev: Add the client ID and client secret to `terraform/environment/wildsea-dev/terraform.tfvars` as `google_client_id` and `google_client_secret`

--- a/ui/src/sectionBurnable.tsx
+++ b/ui/src/sectionBurnable.tsx
@@ -161,7 +161,7 @@ export const SectionBurnable: React.FC<SectionDefinition> = (props) => {
           <>
             <input
               type="text"
-              value={item.name}
+              value={item.name || ''}
               onChange={(e) => handleItemChange(index, 'name', e.target.value)}
               placeholder={intl.formatMessage({ id: "sectionObject.itemName" })}
             />

--- a/ui/src/sectionDeltaGreenSkills.tsx
+++ b/ui/src/sectionDeltaGreenSkills.tsx
@@ -263,7 +263,7 @@ export const SectionDeltaGreenSkills: React.FC<SectionDefinition> = (props) => {
           <>
             <input
               type="text"
-              value={item.name}
+              value={item.name || ''}
               onChange={(e) => handleItemChange(index, 'name', e.target.value)}
               placeholder={intl.formatMessage({ id: "deltaGreenSkills.skill" })}
             />
@@ -272,7 +272,7 @@ export const SectionDeltaGreenSkills: React.FC<SectionDefinition> = (props) => {
                 type="number"
                 min="0"
                 max="99"
-                value={item.roll}
+                value={item.roll || 0}
                 onChange={(e) => handleItemChange(index, 'roll', parseInt(e.target.value) || 0)}
                 placeholder={intl.formatMessage({ id: "deltaGreenSkills.roll" })}
               />

--- a/ui/src/sectionDeltaGreenStats.tsx
+++ b/ui/src/sectionDeltaGreenStats.tsx
@@ -117,7 +117,7 @@ export const SectionDeltaGreenStats: React.FC<SectionDefinition> = (props) => {
           <>
             <input
               type="text"
-              value={item.name}
+              value={item.name || ''}
               onChange={(e) => handleItemChange(index, 'name', e.target.value)}
               placeholder={intl.formatMessage({ id: "deltaGreenStats.statistic" })}
             />
@@ -125,13 +125,13 @@ export const SectionDeltaGreenStats: React.FC<SectionDefinition> = (props) => {
               type="number"
               min="0"
               max="18"
-              value={item.score}
+              value={item.score || 0}
               onChange={(e) => handleItemChange(index, 'score', parseInt(e.target.value) || 0)}
               placeholder={intl.formatMessage({ id: "deltaGreenStats.score" })}
             />
             <input
               type="text"
-              value={item.distinguishingFeatures}
+              value={item.distinguishingFeatures || ''}
               onChange={(e) => handleItemChange(index, 'distinguishingFeatures', e.target.value)}
               placeholder={intl.formatMessage({ id: "deltaGreenStats.distinguishingFeatures" })}
               maxLength={40}

--- a/ui/src/sectionKeyValue.tsx
+++ b/ui/src/sectionKeyValue.tsx
@@ -49,7 +49,7 @@ export const SectionKeyValue: React.FC<SectionDefinition> = (props) => {
           renderContent={(item) => (
             <input
               type="text"
-              value={item.value}
+              value={item.value || ''}
               onChange={(e) => handleValueChange(item, e.target.value, content, setContent, updateSection, isEditing)}
               disabled={!mayEditSheet}
             />
@@ -83,18 +83,18 @@ export const SectionKeyValue: React.FC<SectionDefinition> = (props) => {
           <>
             <input
               type="text"
-              value={item.name}
+              value={item.name || ''}
               onChange={(e) => handleItemChange(index, 'name', e.target.value)}
               placeholder={intl.formatMessage({ id: "sectionObject.itemName" })}
             />
             <input
               type="text"
-              value={item.value}
+              value={item.value || ''}
               onChange={(e) => handleItemChange(index, 'value', e.target.value)}
               placeholder={intl.formatMessage({ id: "sectionKeyValue.itemValue" })}
             />
             <textarea
-              value={item.description}
+              value={item.description || ''}
               onChange={(e) => handleItemChange(index, 'description', e.target.value)}
               placeholder={intl.formatMessage({ id: "sectionObject.itemDescription" })}
             />

--- a/ui/src/sectionRichText.tsx
+++ b/ui/src/sectionRichText.tsx
@@ -35,7 +35,7 @@ export const SectionRichText: React.FC<SectionDefinition> = (props) => {
         {content.items.map((item, index) => (
           <div key={`${item.id}-${index}`} className="rich-text-edit">
                 <SectionItemDescription
-                    value={item.markdown}
+                    value={item.markdown || ''}
                     onChange={(value) => handleItemChange(index, value ?? "")}
                     placeholder={intl.formatMessage({ id: "sectionRichText.sampleContent" })}
                 />

--- a/ui/src/sectionTrackable.tsx
+++ b/ui/src/sectionTrackable.tsx
@@ -122,7 +122,7 @@ export const SectionTrackable: React.FC<SectionDefinition> = (props) => {
           <>
             <input
               type="text"
-              value={item.name}
+              value={item.name || ''}
               onChange={(e) => handleItemChange(index, 'name', e.target.value)}
               placeholder={intl.formatMessage({ id: "sectionObject.itemName" })}
             />
@@ -136,7 +136,7 @@ export const SectionTrackable: React.FC<SectionDefinition> = (props) => {
               </button>
             </div>
             <textarea
-              value={item.description}
+              value={item.description || ''}
               onChange={(e) => handleItemChange(index, 'description', e.target.value)}
               placeholder={intl.formatMessage({ id: "sectionObject.itemDescription" })}
             />


### PR DESCRIPTION
## Summary
- Fixed React controlled component warnings occurring when editing empty KeyValue fields
- Applied similar fixes across all section components (Burnable, Trackable, DeltaGreenStats, DeltaGreenSkills, RichText)
- Ensured all input values default to empty strings instead of undefined
- Prevents warnings across all browser windows watching the player sheet

## Test plan
- [x] Deploy to dev environment
- [x] Test KeyValue section editing with empty values
- [x] Verify no React controlled component warnings appear
- [x] Test across multiple browser windows for real-time sync

🤖 Generated with [Claude Code](https://claude.ai/code)