### PR TITLE
Improve section edit form button layout and text

### DIFF
--- a/ui/src/baseSection.tsx
+++ b/ui/src/baseSection.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { SheetSection, UpdateSectionInput } from "../../appsync/graphql";
-import { FormattedMessage, useIntl } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { FaPencilAlt } from 'react-icons/fa';
 import { useToast } from './notificationToast';
 import { generateClient, GraphQLResult } from 'aws-amplify/api';
@@ -30,6 +30,8 @@ interface BaseSectionProps<T extends BaseSectionItem> {
     renderEditForm: (
         content: BaseSectionContent<T>,
         setContent: React.Dispatch<React.SetStateAction<BaseSectionContent<T>>>,
+        handleUpdate: () => void,
+        handleCancel: () => void,
     ) => React.ReactNode;
 }
 
@@ -118,13 +120,7 @@ export const BaseSection = <T extends BaseSectionItem>({
                     onChange={(e) => setSectionName(e.target.value)}
                     placeholder={intl.formatMessage({ id: "sectionName" })}
                 />
-                {renderEditForm(content, setContent)}
-                <button onClick={handleUpdate} className="btn-standard btn-small">
-                    <FormattedMessage id="save" />
-                </button>
-                <button onClick={handleCancel} className="btn-secondary btn-small">
-                    <FormattedMessage id="cancel" />
-                </button>
+                {renderEditForm(content, setContent, handleUpdate, handleCancel)}
             </div>
         );
     }

--- a/ui/src/components/SectionEditForm.tsx
+++ b/ui/src/components/SectionEditForm.tsx
@@ -8,6 +8,8 @@ interface SectionEditFormProps<T extends BaseSectionItem> {
   readonly renderItemEdit: (item: T, index: number) => React.ReactNode;
   readonly addItem: () => void;
   readonly removeItem: (index: number) => void;
+  readonly handleUpdate: () => void;
+  readonly handleCancel: () => void;
 }
 
 export function SectionEditForm<T extends BaseSectionItem>({
@@ -15,7 +17,9 @@ export function SectionEditForm<T extends BaseSectionItem>({
   setContent,
   renderItemEdit,
   addItem,
-  removeItem
+  removeItem,
+  handleUpdate,
+  handleCancel
 }: Readonly<SectionEditFormProps<T>>) {
   return (
     <div className="section-items-edit">
@@ -39,9 +43,17 @@ export function SectionEditForm<T extends BaseSectionItem>({
           </button>
         </div>
       ))}
-      <button onClick={addItem} className="btn-edit-form">
-        <FormattedMessage id={`sectionObject.addItem`} />
-      </button>
+      <div className="section-edit-buttons">
+        <button onClick={addItem} className="btn-standard btn-small">
+          <FormattedMessage id={`sectionObject.addItem`} />
+        </button>
+        <button onClick={handleUpdate} className="btn-standard btn-small">
+          <FormattedMessage id="save" />
+        </button>
+        <button onClick={handleCancel} className="btn-secondary btn-small">
+          <FormattedMessage id="cancel" />
+        </button>
+      </div>
     </div>
   );
 }

--- a/ui/src/sectionBurnable.tsx
+++ b/ui/src/sectionBurnable.tsx
@@ -116,7 +116,7 @@ export const SectionBurnable: React.FC<SectionDefinition> = (props) => {
         )});
     };
 
-  const renderEditForm = (content: SectionTypeBurnable, setContent: React.Dispatch<React.SetStateAction<SectionTypeBurnable>>) => {
+  const renderEditForm = (content: SectionTypeBurnable, setContent: React.Dispatch<React.SetStateAction<SectionTypeBurnable>>, handleUpdate: () => void, handleCancel: () => void) => {
     const handleAddItem = () => {
       const newItems = [...content.items, { id: uuidv4(), name: '', length: 1, states: ['unticked' as BurnableState], description: '' }];
       setContent({ ...content, items: newItems });
@@ -183,6 +183,8 @@ export const SectionBurnable: React.FC<SectionDefinition> = (props) => {
         )}
         addItem={handleAddItem}
         removeItem={handleRemoveItem}
+        handleUpdate={handleUpdate}
+        handleCancel={handleCancel}
       />
     );
   };

--- a/ui/src/sectionDeltaGreenSkills.tsx
+++ b/ui/src/sectionDeltaGreenSkills.tsx
@@ -231,7 +231,7 @@ export const SectionDeltaGreenSkills: React.FC<SectionDefinition> = (props) => {
     );
   };
 
-  const renderEditForm = (content: SectionTypeDeltaGreenSkills, setContent: React.Dispatch<React.SetStateAction<SectionTypeDeltaGreenSkills>>) => {
+  const renderEditForm = (content: SectionTypeDeltaGreenSkills, setContent: React.Dispatch<React.SetStateAction<SectionTypeDeltaGreenSkills>>, handleUpdate: () => void, handleCancel: () => void) => {
     const handleAddItem = () => {
       const newItems = [...content.items, { 
         id: uuidv4(), 
@@ -323,6 +323,8 @@ export const SectionDeltaGreenSkills: React.FC<SectionDefinition> = (props) => {
         )}
         addItem={handleAddItem}
         removeItem={handleRemoveItem}
+        handleUpdate={handleUpdate}
+        handleCancel={handleCancel}
       />
     );
   };

--- a/ui/src/sectionDeltaGreenStats.tsx
+++ b/ui/src/sectionDeltaGreenStats.tsx
@@ -86,7 +86,7 @@ export const SectionDeltaGreenStats: React.FC<SectionDefinition> = (props) => {
     );
   };
 
-  const renderEditForm = (content: SectionTypeDeltaGreenStats, setContent: React.Dispatch<React.SetStateAction<SectionTypeDeltaGreenStats>>) => {
+  const renderEditForm = (content: SectionTypeDeltaGreenStats, setContent: React.Dispatch<React.SetStateAction<SectionTypeDeltaGreenStats>>, handleUpdate: () => void, handleCancel: () => void) => {
     const handleAddItem = () => {
       const newItems = [...content.items, { 
         id: uuidv4(), 
@@ -140,6 +140,8 @@ export const SectionDeltaGreenStats: React.FC<SectionDefinition> = (props) => {
         )}
         addItem={handleAddItem}
         removeItem={handleRemoveItem}
+        handleUpdate={handleUpdate}
+        handleCancel={handleCancel}
       />
     );
   };

--- a/ui/src/sectionKeyValue.tsx
+++ b/ui/src/sectionKeyValue.tsx
@@ -58,7 +58,7 @@ export const SectionKeyValue: React.FC<SectionDefinition> = (props) => {
       ));
   };
 
-  const renderEditForm = (content: SectionTypeKeyValue, setContent: React.Dispatch<React.SetStateAction<SectionTypeKeyValue>>) => {
+  const renderEditForm = (content: SectionTypeKeyValue, setContent: React.Dispatch<React.SetStateAction<SectionTypeKeyValue>>, handleUpdate: () => void, handleCancel: () => void) => {
     const handleAddItem = () => {
       const newItems = [...content.items, { id: uuidv4(), name: '', value: '', description: '' }];
       setContent({ ...content, items: newItems });
@@ -102,6 +102,8 @@ export const SectionKeyValue: React.FC<SectionDefinition> = (props) => {
         )}
         addItem={handleAddItem}
         removeItem={handleRemoveItem}
+        handleUpdate={handleUpdate}
+        handleCancel={handleCancel}
       />
     );
   };

--- a/ui/src/sectionTrackable.tsx
+++ b/ui/src/sectionTrackable.tsx
@@ -88,7 +88,7 @@ export const SectionTrackable: React.FC<SectionDefinition> = (props) => {
       ));
   };
 
-  const renderEditForm = (content: SectionTypeTrackable, setContent: React.Dispatch<React.SetStateAction<SectionTypeTrackable>>) => {
+  const renderEditForm = (content: SectionTypeTrackable, setContent: React.Dispatch<React.SetStateAction<SectionTypeTrackable>>, handleUpdate: () => void, handleCancel: () => void) => {
     const handleAddItem = () => {
       const newItems = [...content.items, { id: uuidv4(), name: '', length: 1, ticked: 0, description: '' }];
       setContent({ ...content, items: newItems });
@@ -144,6 +144,8 @@ export const SectionTrackable: React.FC<SectionDefinition> = (props) => {
         )}
         addItem={handleAddItem}
         removeItem={handleRemoveItem}
+        handleUpdate={handleUpdate}
+        handleCancel={handleCancel}
       />
     );
   };

--- a/ui/src/translations.ts
+++ b/ui/src/translations.ts
@@ -194,7 +194,7 @@ export const messages = {
 
     // Common section translations
     'sectionObject.updateError': 'Failed to update the section',
-    'sectionObject.addItem': '➕',
+    'sectionObject.addItem': 'Add New Item',
     'sectionObject.removeItem': '❌',
     'sectionObject.showEmpty': 'Show Empty Items',
     'sectionObject.burntEmoji': '🔥',


### PR DESCRIPTION
## Summary
- Moved Save Changes and Cancel buttons into SectionEditForm component for better organization
- Positioned Add New Item, Save Changes, and Cancel buttons together at the bottom of edit forms
- Changed Add Item button from ➕ emoji to "Add New Item" text for clarity
- Applied consistent btn-standard/btn-secondary styling to all buttons
- Grouped buttons in section-edit-buttons div for improved layout

## Changes Made
- **SectionEditForm.tsx**: Added handleUpdate/handleCancel props and moved all form control buttons into the component
- **baseSection.tsx**: Updated to pass handlers to SectionEditForm and removed duplicate button rendering
- **All section components**: Updated renderEditForm signatures to accept new handler parameters
- **translations.ts**: Changed sectionObject.addItem from "➕" to "Add New Item"

## Benefits
- More cohesive edit form UI with all controls in one logical place
- Clearer button labeling improves usability
- Consistent styling and positioning across all section types
- Better separation of concerns between BaseSection and SectionEditForm

## Test plan
- [x] Deploy to dev environment 
- [x] Verify all section edit forms show the new button layout
- [x] Test Add New Item, Save Changes, and Cancel functionality
- [x] Confirm consistent styling across all section types

🤖 Generated with [Claude Code](https://claude.ai/code)