### PR TITLE
Fix section title edit input width overflow

### DIFF
--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -566,6 +566,7 @@
 
 .section-title-edit {
   width: 100%;
+  box-sizing: border-box;
   text-align: center;
   font-size: 1.5rem;
   font-weight: bold;


### PR DESCRIPTION
## Summary
- Fixed section title edit input extending beyond section container boundaries
- Added proper box-sizing to prevent width overflow

## Problem
The section title edit input was jutting out beyond the right side of section containers when in edit mode, as shown in the provided screenshot. This was caused by `width: 100%` not accounting for the element's padding and borders.

## Solution
Added `box-sizing: border-box` to the `.section-title-edit` CSS class. This ensures that padding and borders are included within the element's total width rather than added on top of it, keeping the input properly contained within the section boundaries.

## Test plan
- [x] Verify section title edit inputs no longer overflow container boundaries
- [x] Confirm inputs remain centered and properly sized
- [x] Test across different section types and sizes

🤖 Generated with [Claude Code](https://claude.ai/code)