### PR TITLE
Add missing aria-labels for character name and game edit inputs

### DIFF
--- a/ui/src/editGame.tsx
+++ b/ui/src/editGame.tsx
@@ -61,11 +61,13 @@ export const EditGameModal: React.FC<EditGameModalProps> = ({
         value={gameName}
         onChange={(e) => setGameName(e.target.value)}
         placeholder={intl.formatMessage({ id: "editGameModal.namePlaceholder" })}
+        aria-label={intl.formatMessage({ id: "editGameModal.namePlaceholder" })}
       />
       <SectionItemDescription
         value={gameDescription}
         onChange={setGameDescription}
         placeholder={intl.formatMessage({ id: "editGameModal.descriptionPlaceholder" })}
+        ariaLabel={intl.formatMessage({ id: "editGameModal.descriptionPlaceholder" })}
       />
       <div className="modal-buttons">
         <button onClick={onRequestClose} className="btn-secondary btn-small"><FormattedMessage id="cancel" /></button>

--- a/ui/src/playerSheetTab.tsx
+++ b/ui/src/playerSheetTab.tsx
@@ -410,6 +410,7 @@ const SheetHeader: React.FC<{
             value={characterName}
             onChange={(e) => setCharacterName(e.target.value)}
             placeholder={intl.formatMessage({ id: "characterName" })}
+            aria-label={intl.formatMessage({ id: "characterName" })}
           />
           <button onClick={handleSave} className="btn-standard btn-small"><FormattedMessage id="save" /></button>
           <button onClick={() => setIsEditing(false)} className="btn-secondary btn-small"><FormattedMessage id="cancel" /></button>


### PR DESCRIPTION
## Summary
Complete accessibility coverage by adding missing aria-labels to remaining input fields:
- Character name input in player sheet edit mode
- Game name input in edit game modal  
- Game description MDEditor in edit game modal

Addresses part of #176.

## Test plan
- [x] Verify character name input has proper aria-label when editing
- [x] Verify game edit modal inputs have proper aria-labels for screen readers
- [x] Confirm accessibility tools no longer report missing form labels for these inputs

🤖 Generated with [Claude Code](https://claude.ai/code)