### PR TITLE
Fix null gameType error in ship operations

### DIFF
--- a/graphql/function/checkPlayerSheetAccessWithFirefly/checkPlayerSheetAccessWithFirefly.ts
+++ b/graphql/function/checkPlayerSheetAccessWithFirefly/checkPlayerSheetAccessWithFirefly.ts
@@ -62,6 +62,7 @@ export function response(
   context.stash.gameId = context.result.gameId;
   context.stash.fireflyUserId = context.result.fireflyUserId;
   context.stash.gameName = context.result.gameName;
+  context.stash.gameType = context.result.gameType;
   context.stash.gameDescription = context.result.gameDescription;
   context.stash.characterName = context.result.characterName;
   context.stash.createdAt = context.result.createdAt;

--- a/graphql/function/createShip/createShip.ts
+++ b/graphql/function/createShip/createShip.ts
@@ -28,6 +28,7 @@ export function request(
       gameId: input.gameId,
       userId: id,
       gameName: context.prev.result.gameName,
+      gameType: context.prev.result.gameType,
       gameDescription: context.prev.result.gameDescription,
       characterName: input.characterName,
       fireflyUserId: context.prev.result.fireflyUserId,


### PR DESCRIPTION
## Summary
- Fix null gameType error in deletePlayer and createShip operations
- Add missing gameType to context.stash in checkPlayerSheetAccessWithFirefly resolver

## Background
The deletePlayer resolver was failing with "Cannot return null for non-nullable type: 'String' within parent 'PlayerSheetSummary'" because it expects gameType to be available in context.stash, but the checkPlayerSheetAccessWithFirefly function wasn't setting it.

## Changes
- Add `context.stash.gameType = context.result.gameType;` to checkPlayerSheetAccessWithFirefly
- Include gameType in createShip data for consistency

## Test plan
- [x] Create Ship operation works without gameType null error
- [x] Delete Ship operation works without gameType null error  
- [x] Deployed and tested in development environment

🤖 Generated with [Claude Code](https://claude.ai/code)