### PR TITLE
Fix delete confirmation checkbox staying checked across modal instances

### DIFF
--- a/ui/src/deleteGame.tsx
+++ b/ui/src/deleteGame.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Modal from 'react-modal';
 import { FormattedMessage, useIntl } from 'react-intl';
 
@@ -15,6 +15,13 @@ export const DeleteGameModal: React.FC<DeleteGameModalProps> = ({
 }) => {
   const [isConfirmed, setIsConfirmed] = useState(false);
   const intl = useIntl();
+
+  // Reset checkbox when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      setIsConfirmed(false);
+    }
+  }, [isOpen]);
 
   const handleConfirm = () => {
     onConfirm();

--- a/ui/src/deletePlayer.tsx
+++ b/ui/src/deletePlayer.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Modal from 'react-modal';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { TypeShip } from '../../graphql/lib/constants/entityTypes';
@@ -20,6 +20,13 @@ export const DeletePlayerModal: React.FC<DeletePlayerModalProps> = ({
 }) => {
   const [isConfirmed, setIsConfirmed] = useState(false);
   const intl = useIntl();
+
+  // Reset checkbox when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      setIsConfirmed(false);
+    }
+  }, [isOpen]);
 
   const handleConfirm = () => {
     onConfirm();


### PR DESCRIPTION
## Summary
- Fix checkbox persistence issue where delete confirmation checkbox remained checked after deleting/kicking a player or ship
- Reset checkbox state when modal opens to ensure clean slate for each operation

## Root Cause
Both `DeletePlayerModal` and `DeleteGameModal` components use `useState(false)` for the confirmation checkbox, but React doesn't unmount modal components when they close - it just hides them. This caused the checkbox state to persist across multiple modal instances.

## Solution
Added `useEffect` hook to both modal components that resets `isConfirmed` to `false` whenever the `isOpen` prop becomes `true`, ensuring each modal instance starts with an unchecked confirmation checkbox.

## Changes
- **ui/src/deletePlayer.tsx**: Added useEffect to reset checkbox on modal open
- **ui/src/deleteGame.tsx**: Added useEffect to reset checkbox on modal open

## Test Plan
- [x] Test deleting/kicking multiple players in succession
- [ ] Test deleting multiple games in succession  
- [x] Verify checkbox is unchecked for each new modal instance
- [x] Confirm modal still requires checkbox to be manually checked before allowing deletion
- [x] Deploy to dev environment successfully

Resolves #237

🤖 Generated with [Claude Code](https://claude.ai/code)