### PR TITLE
Fix tippy accessibility warning by wrapping interactive elements

### DIFF
--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -2325,7 +2325,8 @@
 .btn-icon.info:focus {
   background: none;
   color: var(--color-primary-hover);
-  outline: none;
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
 }
 
 .btn-icon.edit {

--- a/ui/src/components/SectionItem.tsx
+++ b/ui/src/components/SectionItem.tsx
@@ -19,21 +19,23 @@ export function SectionItem<T extends BaseSectionItem>({ item, renderContent }: 
       <span>{item.name}</span>
       {renderContent(item)}
       { item.description && (
-      <Tippy
-        content={<ReactMarkdown>{item.description}</ReactMarkdown> }
-        interactive={true}
-        trigger="click"
-        arrow={true}
-        placement="top"
-        className="markdown-tippy"
-      >
-        <button 
-          className="btn-icon info"
-          aria-label={intl.formatMessage({ id: 'showInfo.itemDescription' })}
+      <span>
+        <Tippy
+          content={<ReactMarkdown>{item.description}</ReactMarkdown> }
+          interactive={true}
+          trigger="click"
+          arrow={true}
+          placement="top"
+          className="markdown-tippy"
         >
-          {intl.formatMessage({ id: 'showInfo' })}
-        </button>
-      </Tippy>
+          <button 
+            className="btn-icon info"
+            aria-label={intl.formatMessage({ id: 'showInfo.itemDescription' })}
+          >
+            {intl.formatMessage({ id: 'showInfo' })}
+          </button>
+        </Tippy>
+      </span>
       )}
     </div>
   );

--- a/ui/src/frame.tsx
+++ b/ui/src/frame.tsx
@@ -31,21 +31,23 @@ export const TopBar: React.FC<TopBarProps> = ({ title, userEmail, gameDescriptio
     <h1>
       {title}
       {gameDescription && (
-        <Tippy
-          content={<ReactMarkdown>{gameDescription}</ReactMarkdown>}
-          interactive={true}
-          trigger="click"
-          arrow={true}
-          placement="bottom"
-          className="markdown-tippy"
-        >
-          <button 
-            className="btn-icon info"
-            aria-label={intl.formatMessage({ id: 'showInfo.gameDescription' })}
+        <span>
+          <Tippy
+            content={<ReactMarkdown>{gameDescription}</ReactMarkdown>}
+            interactive={true}
+            trigger="click"
+            arrow={true}
+            placement="bottom"
+            className="markdown-tippy"
           >
-            {intl.formatMessage({ id: 'showInfo' })}
-          </button>
-        </Tippy>
+            <button 
+              className="btn-icon info"
+              aria-label={intl.formatMessage({ id: 'showInfo.gameDescription' })}
+            >
+              {intl.formatMessage({ id: 'showInfo' })}
+            </button>
+          </Tippy>
+        </span>
       )}
       {isFirefly && onEditGame && (
         <button className="btn-standard btn-small edit" onClick={onEditGame}>


### PR DESCRIPTION
## Summary
- Wrap interactive Tippy elements with span tags in `frame.tsx` and `SectionItem.tsx` 
- Creates proper DOM source order for keyboard navigation accessibility
- Add visible focus outline for info buttons to improve keyboard navigation
- Follows tippy.js documentation recommendations for interactive elements

## Test plan
- [x] Verify no console warnings appear when clicking tippy info buttons
- [x] Test keyboard navigation to interactive tippy content works properly
- [x] Confirm info buttons show visible focus indicator when tabbed to
- [x] Confirm existing functionality remains unchanged

Resolves #833

🤖 Generated with [Claude Code](https://claude.ai/code)