### PR TITLE
Add NPC dice rolling functionality with enhanced tracking

### DIFF
--- a/appsync/graphql.ts
+++ b/appsync/graphql.ts
@@ -81,8 +81,10 @@ export type DiceRoll = {
   messageIndex: Scalars['Int']['output'];
   playerId: Scalars['ID']['output'];
   playerName: Scalars['String']['output'];
+  proxyRoll: Scalars['Boolean']['output'];
   rollType: Scalars['String']['output'];
   rolledAt: Scalars['AWSDateTime']['output'];
+  rolledBy: Scalars['String']['output'];
   target: Scalars['Int']['output'];
   type: Scalars['String']['output'];
   value: Scalars['Int']['output'];
@@ -259,6 +261,7 @@ export type RollDiceInput = {
   action?: InputMaybe<Scalars['String']['input']>;
   dice: Array<DiceInput>;
   gameId: Scalars['ID']['input'];
+  onBehalfOf?: InputMaybe<Scalars['ID']['input']>;
   rollType: Scalars['String']['input'];
   target: Scalars['Int']['input'];
 };

--- a/appsync/schema.ts
+++ b/appsync/schema.ts
@@ -117,7 +117,7 @@
       export const rollDiceMutation = `
         mutation rollDice($input: RollDiceInput!) {
           rollDice(input: $input) {
-            gameId playerId playerName dice { ... on SingleDie { __typename type size value } } rollType target grade action diceList { ... on SingleDie { __typename type size value } } value rolledAt type messageIndex
+            gameId playerId playerName dice { ... on SingleDie { __typename type size value } } rollType target grade action diceList { ... on SingleDie { __typename type size value } } value rolledAt rolledBy proxyRoll type messageIndex
           }
         }
       `;
@@ -151,7 +151,7 @@
       export const diceRolledSubscription = `
         subscription diceRolled($gameId: ID!) {
           diceRolled(gameId: $gameId) {
-            gameId playerId playerName dice { ... on SingleDie { __typename type size value } } rollType target grade action diceList { ... on SingleDie { __typename type size value } } value rolledAt type messageIndex
+            gameId playerId playerName dice { ... on SingleDie { __typename type size value } } rollType target grade action diceList { ... on SingleDie { __typename type size value } } value rolledAt rolledBy proxyRoll type messageIndex
           }
         }
       `;

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -195,6 +195,7 @@ input RollDiceInput {
   action: String
   rollType: String!
   target: Int!
+  onBehalfOf: ID
 }
 
 type DiceRoll @aws_cognito_user_pools {
@@ -209,6 +210,8 @@ type DiceRoll @aws_cognito_user_pools {
   diceList: [Dice!]!
   value: Int!
   rolledAt: AWSDateTime!
+  rolledBy: String!
+  proxyRoll: Boolean!
   type: String!
   messageIndex: Int!
 }

--- a/graphql/tests/rollDice.test.ts
+++ b/graphql/tests/rollDice.test.ts
@@ -1,6 +1,7 @@
 import { request, response } from "../mutation/rollDice/rollDice";
 import { Context } from "@aws-appsync/utils";
 import { RollTypes, Grades } from "../lib/constants/rollTypes";
+import type { RollDiceInput } from "../../appsync/graphql";
 
 // Mock the util functions
 jest.mock("@aws-appsync/utils", () => ({
@@ -24,33 +25,58 @@ const mockPlayerSheet = {
   userId: "test-user-id",
   gameId: "test-game-id",
   characterName: "Test Character",
-  type: "character",
+  type: "CHARACTER",
 };
 
-const mockContext = {
-  identity: {
-    sub: "test-user-id",
-  },
-  arguments: {
-    input: {
-      gameId: "test-game-id",
-      dice: [{ type: "d100", size: 100 }],
-      rollType: RollTypes.DELTA_GREEN,
-      target: 50,
+const mockShipSheet = {
+  userId: "ship-id",
+  gameId: "test-game-id",
+  characterName: "Test Ship",
+  type: "SHIP",
+};
+
+interface MockContextOverrides {
+  input?: Partial<RollDiceInput>;
+  stash?: Record<string, unknown>;
+  result?: unknown[];
+  identity?: { sub: string };
+}
+
+const createMockContext = (overrides: MockContextOverrides = {}) =>
+  ({
+    identity: {
+      sub: "test-user-id",
+      ...overrides.identity,
     },
-  },
-  stash: {
-    input: {
-      gameId: "test-game-id",
-      dice: [{ type: "d100", size: 100 }],
-      rollType: RollTypes.DELTA_GREEN,
-      target: 50,
+    arguments: {
+      input: {
+        gameId: "test-game-id",
+        dice: [{ type: "d100", size: 100 }],
+        rollType: RollTypes.DELTA_GREEN,
+        target: 50,
+        ...overrides.input,
+      },
     },
-    playerId: "test-user-id",
-  },
-  result: mockPlayerSheet,
-  error: null,
-} as unknown as Context;
+    stash: {
+      input: {
+        gameId: "test-game-id",
+        dice: [{ type: "d100", size: 100 }],
+        rollType: RollTypes.DELTA_GREEN,
+        target: 50,
+        ...overrides.input,
+      },
+      playerId: "test-user-id",
+      onBehalfOf: undefined,
+      ...overrides.stash,
+    },
+    result: {
+      data:
+        overrides.result !== undefined
+          ? { "Wildsea-dev": overrides.result }
+          : { "Wildsea-dev": [mockPlayerSheet] },
+    },
+    error: null,
+  }) as unknown as Context;
 
 describe("rollDice resolver", () => {
   beforeEach(() => {
@@ -58,14 +84,47 @@ describe("rollDice resolver", () => {
   });
 
   describe("request function", () => {
-    it("should create correct DynamoDB request", () => {
+    it("should create correct DynamoDB BatchGetItem request", () => {
+      const mockContext = createMockContext();
       const result = request(mockContext);
 
       expect(result).toEqual({
-        operation: "GetItem",
-        key: {
-          PK: "GAME#test-game-id",
-          SK: "PLAYER#test-user-id",
+        operation: "BatchGetItem",
+        tables: {
+          "Wildsea-dev": {
+            keys: [
+              {
+                PK: "GAME#test-game-id",
+                SK: "PLAYER#test-user-id",
+              },
+            ],
+          },
+        },
+      });
+    });
+
+    it("should include ship key when onBehalfOf is provided", () => {
+      const contextWithOnBehalfOf = createMockContext({
+        input: { onBehalfOf: "ship-id" },
+      });
+
+      const result = request(contextWithOnBehalfOf);
+
+      expect(result).toEqual({
+        operation: "BatchGetItem",
+        tables: {
+          "Wildsea-dev": {
+            keys: [
+              {
+                PK: "GAME#test-game-id",
+                SK: "PLAYER#test-user-id",
+              },
+              {
+                PK: "GAME#test-game-id",
+                SK: "PLAYER#ship-id",
+              },
+            ],
+          },
         },
       });
     });
@@ -76,6 +135,7 @@ describe("rollDice resolver", () => {
       // Mock Math.random to return 0 (which becomes 1)
       jest.spyOn(Math, "random").mockReturnValue(0);
 
+      const mockContext = createMockContext();
       const result = response(mockContext);
 
       expect(result.grade).toBe(Grades.CRITICAL_SUCCESS);
@@ -87,6 +147,7 @@ describe("rollDice resolver", () => {
       // Mock Math.random to return 0.99 (which becomes 100)
       jest.spyOn(Math, "random").mockReturnValue(0.99);
 
+      const mockContext = createMockContext();
       const result = response(mockContext);
 
       expect(result.grade).toBe(Grades.FUMBLE);
@@ -98,6 +159,7 @@ describe("rollDice resolver", () => {
       // Mock Math.random to return 0.21 (which becomes 22, all digits same and <= 50)
       jest.spyOn(Math, "random").mockReturnValue(0.21);
 
+      const mockContext = createMockContext();
       const result = response(mockContext);
 
       expect(result.grade).toBe(Grades.CRITICAL_SUCCESS);
@@ -109,6 +171,7 @@ describe("rollDice resolver", () => {
       // Mock Math.random to return 0.65 (which becomes 66, all digits same and > 50)
       jest.spyOn(Math, "random").mockReturnValue(0.65);
 
+      const mockContext = createMockContext();
       const result = response(mockContext);
 
       expect(result.grade).toBe(Grades.FUMBLE);
@@ -120,6 +183,7 @@ describe("rollDice resolver", () => {
       // Mock Math.random to return 0.24 (which becomes 25, <= 50)
       jest.spyOn(Math, "random").mockReturnValue(0.24);
 
+      const mockContext = createMockContext();
       const result = response(mockContext);
 
       expect(result.grade).toBe(Grades.SUCCESS);
@@ -131,6 +195,7 @@ describe("rollDice resolver", () => {
       // Mock Math.random to return 0.74 (which becomes 75, > 50)
       jest.spyOn(Math, "random").mockReturnValue(0.74);
 
+      const mockContext = createMockContext();
       const result = response(mockContext);
 
       expect(result.grade).toBe(Grades.FAILURE);
@@ -142,6 +207,7 @@ describe("rollDice resolver", () => {
       // Mock Math.random to return 0.49 (which becomes 50, exactly equal to target 50)
       jest.spyOn(Math, "random").mockReturnValue(0.49);
 
+      const mockContext = createMockContext();
       const result = response(mockContext);
 
       expect(result.grade).toBe(Grades.SUCCESS);
@@ -151,28 +217,11 @@ describe("rollDice resolver", () => {
 
     it("should return CRITICAL_SUCCESS for matching digits equal to target", () => {
       // Mock Math.random to return 0.32 (which becomes 33, matching digits and = target)
-      const contextWithTarget33 = {
-        ...mockContext,
-        arguments: {
-          input: {
-            gameId: "test-game-id",
-            dice: [{ type: "d100", size: 100 }],
-            rollType: RollTypes.DELTA_GREEN,
-            target: 33,
-          },
-        },
-        stash: {
-          input: {
-            gameId: "test-game-id",
-            dice: [{ type: "d100", size: 100 }],
-            rollType: RollTypes.DELTA_GREEN,
-            target: 33,
-          },
-          playerId: "test-user-id",
-        },
-      } as unknown as Context;
-
       jest.spyOn(Math, "random").mockReturnValue(0.32);
+
+      const contextWithTarget33 = createMockContext({
+        input: { target: 33 },
+      });
 
       const result = response(contextWithTarget33);
 
@@ -182,35 +231,97 @@ describe("rollDice resolver", () => {
     });
   });
 
-  describe("response function - Sum rolls", () => {
-    it("should return NEUTRAL for sum roll type", () => {
-      const sumContext = {
-        ...mockContext,
-        arguments: {
-          input: {
-            gameId: "test-game-id",
-            dice: [
-              { type: "d6", size: 6 },
-              { type: "d6", size: 6 },
-            ],
-            rollType: RollTypes.SUM,
-            target: 7,
-          },
-        },
+  describe("response function - error cases", () => {
+    it("should error when player not found in game (no onBehalfOf)", () => {
+      const contextWithNoPlayer = createMockContext({
+        result: [], // Empty result - no player found
+      });
+
+      expect(() => response(contextWithNoPlayer)).toThrow("Unauthorized");
+    });
+  });
+
+  describe("response function - onBehalfOf ship rolls", () => {
+    it("should return ship name when rolling on behalf of ship", () => {
+      const contextWithShip = createMockContext({
         stash: {
           input: {
             gameId: "test-game-id",
-            dice: [
-              { type: "d6", size: 6 },
-              { type: "d6", size: 6 },
-            ],
-            rollType: RollTypes.SUM,
-            target: 7,
+            dice: [{ type: "d100", size: 100 }],
+            rollType: RollTypes.DELTA_GREEN,
+            target: 50,
           },
           playerId: "test-user-id",
+          onBehalfOf: "ship-id",
         },
-        result: mockPlayerSheet,
-      } as unknown as Context;
+        result: [mockPlayerSheet, mockShipSheet],
+      });
+
+      jest.spyOn(Math, "random").mockReturnValue(0.24);
+
+      const result = response(contextWithShip);
+
+      expect(result.grade).toBe(Grades.SUCCESS);
+      expect(result.playerName).toBe("Test Ship");
+      expect(result.playerId).toBe("ship-id");
+    });
+
+    it("should error if onBehalfOf record is not a ship", () => {
+      const mockNonShip = {
+        userId: "non-ship-id",
+        gameId: "test-game-id",
+        characterName: "Not A Ship",
+        type: "CHARACTER",
+      };
+
+      const contextWithNonShip = createMockContext({
+        stash: {
+          input: {
+            gameId: "test-game-id",
+            dice: [{ type: "d100", size: 100 }],
+            rollType: RollTypes.DELTA_GREEN,
+            target: 50,
+          },
+          playerId: "test-user-id",
+          onBehalfOf: "non-ship-id",
+        },
+        result: [mockPlayerSheet, mockNonShip],
+      });
+
+      expect(() => response(contextWithNonShip)).toThrow("Unauthorized");
+    });
+
+    it("should error if onBehalfOf ID does not exist in game", () => {
+      const contextWithMissingShip = createMockContext({
+        stash: {
+          input: {
+            gameId: "test-game-id",
+            dice: [{ type: "d100", size: 100 }],
+            rollType: RollTypes.DELTA_GREEN,
+            target: 50,
+          },
+          playerId: "test-user-id",
+          onBehalfOf: "non-existent-id",
+        },
+        result: [mockPlayerSheet], // Only player, no ship
+      });
+
+      expect(() => response(contextWithMissingShip)).toThrow("Unauthorized");
+    });
+  });
+
+  describe("response function - Sum rolls", () => {
+    it("should return NEUTRAL for sum roll type", () => {
+      const sumContext = createMockContext({
+        input: {
+          dice: [
+            { type: "d6", size: 6 },
+            { type: "d6", size: 6 },
+          ],
+          rollType: RollTypes.SUM,
+          target: 7,
+        },
+      });
 
       // Mock Math.random to return consistent values
       jest


### PR DESCRIPTION
## Summary
- Add ability to roll dice on behalf of NPCs (ships) using `onBehalfOf` parameter
- Enhanced security with consistent error handling and proper authorization checks
- Improved database access patterns and comprehensive test coverage
- Added audit trail fields (`rolledBy`, `proxyRoll`) for better tracking

## Backend Changes

### GraphQL Schema Updates
- Add `onBehalfOf?: ID` field to `RollDiceInput` for specifying NPC to roll for  
- Add `rolledBy: String\!` field to track who made the roll (always the player)
- Add `proxyRoll: Boolean\!` to distinguish between direct and proxy rolls

### Security Enhancements
- All authorization errors now return generic "Unauthorized" messages for better security
- Improved null checking and validation for database records
- Consolidated ship validation logic with proper type checking
- Enhanced access control for NPC rolling operations

### Database Access Improvements
- Switched from GetItem to BatchGetItem for consistent multi-record access
- Fixed result parsing to use proper `context.result.data[tableName]` structure
- Enhanced record finding with null-safe operations
- Improved error handling for missing or invalid records

### Comprehensive Testing
- Updated all test cases to match new BatchGetItem structure
- Added extensive testing for NPC rolling scenarios and edge cases
- Improved mock context creation with proper TypeScript type safety
- Enhanced error case validation with security-focused assertions
- Added tests for unauthorized access attempts and invalid ship references

## Test Plan
- [x] Normal dice rolling continues to work as before
- [x] NPC dice rolling works with valid `onBehalfOf` ship ID
- [x] Proper error handling for invalid ship IDs
- [x] Proper error handling for non-ship entities
- [x] Security validation prevents unauthorized access
- [x] All existing tests pass with new structure
- [x] New audit fields are properly populated
- [x] GraphQL schema generates correctly

🤖 Generated with [Claude Code](https://claude.ai/code)