### PR TITLE
Implement NPC dice rolling functionality

### DIFF
--- a/graphql/mutation/rollDice/rollDice.ts
+++ b/graphql/mutation/rollDice/rollDice.ts
@@ -34,8 +34,8 @@ export function request(
     }),
   ];
 
-  // Add ship record to batch if rolling on behalf of ship
-  if (input.onBehalfOf) {
+  // Add ship record to batch if rolling on behalf of ship (and it's different from current user)
+  if (input.onBehalfOf && input.onBehalfOf !== identity.sub) {
     keys.push(
       util.dynamodb.toMapValues({
         PK: DDBPrefixGame + "#" + input.gameId,
@@ -85,7 +85,7 @@ export function response(context: Context): DiceRoll {
   let rolledBy: string;
   let proxyRoll: boolean;
 
-  if (onBehalfOf) {
+  if (onBehalfOf && onBehalfOf !== identity.sub) {
     // Find ship record
     const shipSheet = results.find(
       (record) => record.userId === onBehalfOf && record.type == TypeShip,
@@ -100,7 +100,7 @@ export function response(context: Context): DiceRoll {
     rolledBy = playerSheet.characterName;
     proxyRoll = true;
   } else {
-    // Use player's details for the roll
+    // Use player's details for the roll (either no onBehalfOf or onBehalfOf is self)
     rollerName = playerSheet.characterName;
     actualPlayerId = playerId;
     rolledBy = playerSheet.characterName;

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -2508,6 +2508,20 @@
   background-color: var(--color-interactive-active);
 }
 
+.dice-button:disabled {
+  background-color: var(--color-muted-bg);
+  border-color: var(--color-muted-border);
+  color: var(--color-muted-text);
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.dice-button:disabled:hover {
+  background-color: var(--color-muted-bg);
+  border-color: var(--color-muted-border);
+  transform: none;
+}
+
 
 @media screen and (width <= 768px) {
   .dice-roll-modal {

--- a/ui/src/baseSection.tsx
+++ b/ui/src/baseSection.tsx
@@ -38,6 +38,7 @@ export type SectionDefinition = {
   section: SheetSection
   mayEditSheet: boolean
   onUpdate: (updatedSection: SheetSection) => void
+  userSubject: string
 }
 
 export const BaseSection = <T extends BaseSectionItem>({

--- a/ui/src/components/DiceRollFormatter.tsx
+++ b/ui/src/components/DiceRollFormatter.tsx
@@ -22,7 +22,7 @@ const formatGrade = (grade: string, rollType: string, intl: any) => {
   }
 };
 
-const formatDiceDetails = (diceList: any[], grade: string, target?: number, action?: string) => {
+const formatDiceDetails = (diceList: any[], grade: string, target?: number, action?: string, proxyRoll?: boolean, rolledBy?: string, intl?: any) => {
   const values = diceList.map(die => die.value);
   const sum = values.reduce((a, b) => a + b, 0);
   
@@ -38,6 +38,12 @@ const formatDiceDetails = (diceList: any[], grade: string, target?: number, acti
     result = `${rollPart} vs. ${target}; ${grade}`;
   } else {
     result = `${rollPart}; ${grade}`;
+  }
+  
+  // Add proxy roll suffix if present
+  if (proxyRoll && rolledBy && intl) {
+    const proxyText = intl.formatMessage({ id: 'diceRoll.proxyBy' }, { rollerName: rolledBy });
+    result = `${result} ${proxyText}`;
   }
   
   // Add action prefix if present
@@ -117,7 +123,7 @@ export const DiceRollFormatter: React.FC<DiceRollFormatterProps> = ({ roll }) =>
       </div>
       
       <div className="roll-details">
-        {formatDiceDetails(roll.diceList, gradeInfo.text, hasTarget ? roll.target : undefined, roll.action || undefined)}
+        {formatDiceDetails(roll.diceList, gradeInfo.text, hasTarget ? roll.target : undefined, roll.action || undefined, roll.proxyRoll, roll.rolledBy, intl)}
       </div>
     </div>
   );

--- a/ui/src/components/DiceRollModal.tsx
+++ b/ui/src/components/DiceRollModal.tsx
@@ -14,6 +14,7 @@ interface DiceRollModalProps {
   skillValue: number;
   initialAction: string;
   onRollComplete?: (grade: string) => void;
+  onBehalfOf?: string;
 }
 
 export const DiceRollModal: React.FC<DiceRollModalProps> = ({
@@ -22,7 +23,8 @@ export const DiceRollModal: React.FC<DiceRollModalProps> = ({
   gameId,
   skillValue,
   initialAction,
-  onRollComplete
+  onRollComplete,
+  onBehalfOf
 }) => {
   const intl = useIntl();
   const [action, setAction] = useState(initialAction);
@@ -61,6 +63,7 @@ export const DiceRollModal: React.FC<DiceRollModalProps> = ({
         rollType: RollTypes.DELTA_GREEN,
         target,
         action: action.trim() || undefined,
+        onBehalfOf: onBehalfOf || undefined,
       };
       
       const result = await client.graphql({

--- a/ui/src/playerSheetTab.tsx
+++ b/ui/src/playerSheetTab.tsx
@@ -202,6 +202,7 @@ export const PlayerSheetTab: React.FC<{ sheet: PlayerSheet, userSubject: string,
           key={section.sectionId}
           section={section}
           mayEditSheet={mayEditSheet}
+          userSubject={userSubject}
           onUpdate={(updatedSection) => {
             const updatedSections = sheet.sections.map(s =>
               s.sectionId === updatedSection.sectionId ? updatedSection : s

--- a/ui/src/section.tsx
+++ b/ui/src/section.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { getSectionComponent } from './sectionRegistry';
 import { SectionDefinition } from './baseSection';
 
-export const Section: React.FC<SectionDefinition> = ({ section, mayEditSheet, onUpdate }) => {
+export const Section: React.FC<SectionDefinition> = ({ section, mayEditSheet, onUpdate, userSubject }) => {
   const SectionComponent = getSectionComponent(section.sectionType);
 
   if (!SectionComponent) {
     return <div>Unsupported section type</div>;
   }
 
-  return <SectionComponent section={section} mayEditSheet={mayEditSheet} onUpdate={onUpdate} />;
+  return <SectionComponent section={section} mayEditSheet={mayEditSheet} onUpdate={onUpdate} userSubject={userSubject} />;
 };

--- a/ui/src/sectionDeltaGreenSkills.tsx
+++ b/ui/src/sectionDeltaGreenSkills.tsx
@@ -99,6 +99,7 @@ const renderRollControls = (
 };
 
 export const SectionDeltaGreenSkills: React.FC<SectionDefinition> = (props) => {
+  const { section, userSubject } = props;
   const intl = useIntl();
   const [diceModalOpen, setDiceModalOpen] = useState(false);
   const [selectedSkill, setSelectedSkill] = useState<{ name: string; value: number; item: DeltaGreenSkillItem; actionText: string } | null>(null);
@@ -231,6 +232,7 @@ export const SectionDeltaGreenSkills: React.FC<SectionDefinition> = (props) => {
                     <button
                       className="dice-button"
                       onClick={() => handleDiceClick(item.name, numericRoll, item, content, setContent, updateSection)}
+                      disabled={!mayEditSheet}
                       aria-label={intl.formatMessage({ id: 'deltaGreenSkills.rollDice' }, { skillName: item.name })}
                       title={intl.formatMessage({ id: 'deltaGreenSkills.rollDice' }, { skillName: item.name })}
                     >
@@ -346,6 +348,10 @@ export const SectionDeltaGreenSkills: React.FC<SectionDefinition> = (props) => {
     );
   };
 
+  // Determine if we need to pass onBehalfOf
+  const shouldUseOnBehalfOf = userSubject !== section.userId;
+  const onBehalfOfValue = shouldUseOnBehalfOf ? section.userId : undefined;
+
   return (
     <>
       <BaseSection<DeltaGreenSkillItem> {...props} renderItems={renderItems} renderEditForm={renderEditForm} />
@@ -357,6 +363,7 @@ export const SectionDeltaGreenSkills: React.FC<SectionDefinition> = (props) => {
           skillValue={selectedSkill.value}
           initialAction={selectedSkill.actionText}
           onRollComplete={handleRollComplete}
+          onBehalfOf={onBehalfOfValue}
         />
       )}
     </>

--- a/ui/src/sectionDeltaGreenStats.tsx
+++ b/ui/src/sectionDeltaGreenStats.tsx
@@ -66,6 +66,7 @@ const DEFAULT_STATS = [
 ];
 
 export const SectionDeltaGreenStats: React.FC<SectionDefinition> = (props) => {
+  const { section, userSubject } = props;
   const intl = useIntl();
   const [diceModalOpen, setDiceModalOpen] = useState(false);
   const [selectedStat, setSelectedStat] = useState<{ name: string; value: number; actionText: string } | null>(null);
@@ -78,7 +79,7 @@ export const SectionDeltaGreenStats: React.FC<SectionDefinition> = (props) => {
 
   const renderItems = (
         content: SectionTypeDeltaGreenStats,
-        _mayEditSheet: boolean,
+        mayEditSheet: boolean,
         _setContent: React.Dispatch<React.SetStateAction<SectionTypeDeltaGreenStats>>,
         _updateSection: (updatedSection: Partial<SheetSection>) => Promise<void>,
         _isEditing: boolean,
@@ -116,6 +117,7 @@ export const SectionDeltaGreenStats: React.FC<SectionDefinition> = (props) => {
                   <button
                     className="dice-button"
                     onClick={() => handleDiceClick(item.name, numericScore * 5)}
+                    disabled={!mayEditSheet}
                     aria-label={intl.formatMessage({ id: 'deltaGreenStats.rollDice' }, { statName: item.name })}
                     title={intl.formatMessage({ id: 'deltaGreenStats.rollDice' }, { statName: item.name })}
                   >
@@ -226,6 +228,10 @@ export const SectionDeltaGreenStats: React.FC<SectionDefinition> = (props) => {
     );
   };
 
+  // Determine if we need to pass onBehalfOf
+  const shouldUseOnBehalfOf = userSubject !== section.userId;
+  const onBehalfOfValue = shouldUseOnBehalfOf ? section.userId : undefined;
+
   return (
     <>
       <BaseSection<DeltaGreenStatItem> {...props} renderItems={renderItems} renderEditForm={renderEditForm} />
@@ -236,6 +242,7 @@ export const SectionDeltaGreenStats: React.FC<SectionDefinition> = (props) => {
           gameId={props.section.gameId}
           skillValue={selectedStat.value}
           initialAction={selectedStat.actionText}
+          onBehalfOf={onBehalfOfValue}
         />
       )}
     </>

--- a/ui/src/sectionRegistry.tsx
+++ b/ui/src/sectionRegistry.tsx
@@ -9,7 +9,7 @@ import { SectionDeltaGreenDerived, createDefaultDeltaGreenDerivedContent } from 
 import { SectionDeltaGreenSkills, createDefaultDeltaGreenSkillsContent } from './sectionDeltaGreenSkills';
 
 type SectionTypeConfig = {
-  component: React.FC<{ section: SheetSection, mayEditSheet: boolean, onUpdate: (updatedSection: SheetSection) => void }>;
+  component: React.FC<{ section: SheetSection, mayEditSheet: boolean, onUpdate: (updatedSection: SheetSection) => void, userSubject: string }>;
   label: string; // i18n key for translation
   seed: (sheet?: any) => any;
 };

--- a/ui/src/translations.ts
+++ b/ui/src/translations.ts
@@ -189,6 +189,7 @@ export const messages = {
     'diceRoll.grade.FAILURE': 'FAILURE',
     'diceRoll.grade.FUMBLE': 'FUMBLE',
     'diceRoll.grade.NEUTRAL': 'NEUTRAL',
+    'diceRoll.proxyBy': '(by {rollerName})',
     
     // Dice roll display
     'diceRoll.rolled': 'rolled',


### PR DESCRIPTION
## Summary
- Add `onBehalfOf` parameter to rollDice mutation for rolling dice on behalf of NPCs (ships)
- Automatically pass current player sheet UUID as `onBehalfOf` when rolling from other player's dice spots
- Display "(by {name})" for proxy rolls with internationalization support
- Disable dice roll buttons on sheets where users have no edit permissions
- Fix DynamoDB duplicate key error when onBehalfOf equals current user

## Backend Changes
- Enhanced rollDice resolver with `onBehalfOf`, `rolledBy`, and `proxyRoll` fields
- Added security validation ensuring only authorized players can roll for ships
- Fixed BatchGetItem duplicate key issue when rolling for self
- Comprehensive test coverage for all NPC rolling scenarios

## Frontend Changes
- Updated section components to pass user context for automatic onBehalfOf detection
- Enhanced DiceRollModal and DiceRollFormatter to handle proxy rolls
- Added proper disabled state styling for dice buttons
- Internationalized proxy roll display text

## Test plan
- [x] Backend tests pass with proper environment handling
- [x] UI correctly detects when rolling from other player sheets
- [x] Dice buttons disabled on non-editable sheets
- [x] Proxy rolls display correctly with "(by {name})" text
- [x] No duplicate key errors in DynamoDB operations
- [x] Deployed and tested in development environment

Resolves #817

🤖 Generated with [Claude Code](https://claude.ai/code)