### PR TITLE
Add clearer visual indicators for section edit mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,9 +171,11 @@ update this configuration file.
 
 ### Section Development
 
+- sections are in `ui/src/section*.tsx` and `ui/src/components/*.tsx`
 - Section components extend `BaseSectionItem` interface
 - Use `FormattedMessage` and `useIntl` for internationalization
-- Custom edit forms should be created if the generic `SectionEditForm` will not do
+- Custom edit forms should be created only if the generic `SectionEditForm` will not do
+- Each section has a normal/renderItems (for play) form, and an edit/renderEditForm (for edits not normally required during play) form
 - Default section content should be created with appropriate `showEmpty` settings
 - Things in a section that will change regularly during gameplay (e.g. HP or usages) should be able to be changed in the normal form (`renderItems`)
 - Things in a section that will not change regularly during gameplay (e.g. STR, CON, ...) should only be able to be changed in the edit form (`renderEditForm`)

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -562,6 +562,29 @@
   border-radius: 4px;
 }
 
+/* Edit mode styling for sections */
+.section.editing {
+  border: 2px solid var(--color-primary);
+  background-color: var(--color-primary-light);
+  box-shadow: var(--color-shadow-medium);
+  position: relative;
+}
+
+.section-editing-indicator {
+  position: absolute;
+  top: -12px;
+  right: 10px;
+  background-color: var(--color-primary);
+  color: white;
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  font-size: 0.75rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  z-index: 1;
+}
+
 /* Lifted styling for sections when drag is unlocked */
 .sections-unlocked .section {
   box-shadow: var(--color-shadow-section);

--- a/ui/src/baseSection.tsx
+++ b/ui/src/baseSection.tsx
@@ -128,7 +128,10 @@ export const BaseSection = <T extends BaseSectionItem>({
 
     if (isEditing) {
         return (
-            <div className="section" ref={sectionRef}>
+            <div className="section editing" ref={sectionRef}>
+                <div className="section-editing-indicator">
+                    {intl.formatMessage({ id: "editingMode" })}
+                </div>
                 <input
                     type="text"
                     value={sectionName}

--- a/ui/src/translations.ts
+++ b/ui/src/translations.ts
@@ -68,6 +68,7 @@ export const messages = {
     'cancel': '❌ Cancel',
     'close': '✖ Close',
     'edit': '✎ Edit',
+    'editingMode': '✏️ Editing',
     'showInfo': 'ℹ',
     'showInfo.gameDescription': 'Show game description',
     'showInfo.itemDescription': 'Show item description',


### PR DESCRIPTION
## Summary
- Add distinct styling for sections in edit mode with blue border, light background, and shadow
- Include prominent "✏️ Editing" badge in top-right corner of editing sections  
- Add internationalized `editingMode` translation key
- Improve user experience by making edit state immediately obvious

## Test plan
- [ ] Verify sections show clear visual distinction when entering edit mode
- [ ] Confirm "Editing" badge appears in top-right corner during edit
- [ ] Test that edit mode styling doesn't interfere with form functionality
- [ ] Validate accessibility and internationalization work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)