### PR TITLE
Fix accessibility issues in auto-populate section

### DIFF
--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -2576,7 +2576,7 @@ body {
 
 .auto-populate-section p {
   margin-bottom: 15px;
-  color: var(--color-secondary);
+  color: var(--color-text);
   font-style: italic;
 }
 
@@ -2594,6 +2594,7 @@ body {
   border: 1px solid var(--color-border);
   border-radius: 4px;
   background-color: var(--color-surface);
+  color: var(--color-text);
   font-size: 14px;
 }
 

--- a/ui/src/sectionAutoPopulate.tsx
+++ b/ui/src/sectionAutoPopulate.tsx
@@ -127,6 +127,7 @@ export const SectionAutoPopulate: React.FC<AutoPopulateProps> = ({
           value={selectedTemplate}
           onChange={(e) => setSelectedTemplate(e.target.value)}
           disabled={loading}
+          aria-label={intl.formatMessage({ id: "autoPopulate.selectTemplate" })}
         >
           <option value="">
             {intl.formatMessage({ id: "autoPopulate.selectTemplate" })}


### PR DESCRIPTION
## Summary
- Added ARIA label to character template selection dropdown for screen reader accessibility
- Fixed low contrast issues on auto-populate description text by using primary text color
- Fixed low contrast issues on selection dropdown by adding explicit text color

## Test plan
- [x] Test auto-populate section appears when editing character sheets with no sections
- [x] Verify improved text contrast in both game styles (Wildsea and Delta Green)
- [x] Confirm ARIA label is properly applied to dropdown for screen readers
- [x] Test functionality remains intact (template selection and application)

Fixes #856

🤖 Generated with [Claude Code](https://claude.ai/code)