### PR TITLE
Fix join code disappearing after game edit

### DIFF
--- a/ui/src/game.tsx
+++ b/ui/src/game.tsx
@@ -266,7 +266,7 @@ const useGameUpdates = (
               ...currentGame,
               gameName: updatedGame.gameName,
               gameDescription: updatedGame.gameDescription,
-              joinCode: updatedGame.joinCode,
+              joinCode: updatedGame.joinCode ?? currentGame.joinCode,
             }
             setGame(updatedGameData);
             gameRef.current = updatedGameData;


### PR DESCRIPTION
## Summary
- Fix join code disappearing from share modal after GM edits game details
- Preserve existing joinCode in UI when subscription doesn't provide one

## Problem
When a GM edits game details, the join code disappears from the share modal. The `updateGame` resolver doesn't return the `joinCode` field for security reasons, but the UI subscription handler was overwriting the existing `joinCode` with `null/undefined`.

## Solution
Use nullish coalescing operator (`??`) to preserve the existing `joinCode` when the subscription doesn't provide one:
```typescript
joinCode: updatedGame.joinCode ?? currentGame.joinCode,
```

This ensures:
- If subscription provides joinCode (e.g., from `updateJoinCode`), it's used
- If subscription doesn't provide joinCode (e.g., from `updateGame`), existing one is preserved
- Security is maintained - only GMs/Fireflies can see join codes

## Test plan
- [x] Edit game details as GM
- [x] Verify join code remains visible in share modal
- [x] Verify join code updates still work when explicitly changed

Fixes #868

🤖 Generated with [Claude Code](https://claude.ai/code)