### PR TITLE
Add language selector dropdown to user menu

### DIFF
--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -432,7 +432,7 @@ body {
   padding: var(--space-md);
   z-index: 1001;
   box-shadow: var(--shadow-medium);
-  min-width: 120px;
+  min-width: 200px;
 }
 
 .dropdown button {
@@ -457,6 +457,35 @@ body {
 
 .dropdown button:active {
   transform: translateY(0);
+}
+
+.dropdown-separator {
+  border-top: 1px solid var(--color-border);
+  margin: var(--space-sm) 0;
+}
+
+.language-selector {
+  margin-bottom: var(--space-sm);
+}
+
+.language-selector label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin-bottom: var(--space-xs);
+  color: var(--color-text);
+}
+
+.language-selector select {
+  width: 100%;
+  padding: var(--space-md) var(--space-lg);
+  background-color: var(--color-surface);
+  border: none;
+  border-radius: var(--radius-md);
+  color: var(--color-text);
+  font-size: 0.875rem;
+  cursor: pointer;
+  box-sizing: border-box;
 }
 
 .top-bar h1 {

--- a/ui/src/frame.tsx
+++ b/ui/src/frame.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import { FormattedMessage, useIntl } from 'react-intl';
 import Tippy from '@tippyjs/react';
 import ReactMarkdown from 'react-markdown';
+import { supportedLanguages, type SupportedLanguage } from './translations';
 
 function handleSignInClick() {
     signOut(); // sometimes Cognito gets confused; and things you are both logged in, but can't retrieve your email address
@@ -21,10 +22,12 @@ interface TopBarProps {
   isFirefly?: boolean;
   onEditGame?: () => void;
   onShareGame?: () => void;
+  currentLanguage?: SupportedLanguage;
+  onLanguageChange?: (language: SupportedLanguage) => void;
 }
 
 // TopBar component
-export const TopBar: React.FC<TopBarProps> = ({ title, userEmail, gameDescription, isFirefly, onEditGame, onShareGame }) => {
+export const TopBar: React.FC<TopBarProps> = ({ title, userEmail, gameDescription, isFirefly, onEditGame, onShareGame, currentLanguage = 'en', onLanguageChange }) => {
   const [showDropdown, setShowDropdown] = useState(false);
   const intl = useIntl();
 
@@ -81,6 +84,28 @@ export const TopBar: React.FC<TopBarProps> = ({ title, userEmail, gameDescriptio
           </button>
           {showDropdown && (
             <div className="dropdown">
+              {onLanguageChange && (
+                <>
+                  <div className="language-selector">
+                    <label htmlFor="language-select">
+                      <FormattedMessage id="language" />:
+                    </label>
+                    <select
+                      id="language-select"
+                      value={currentLanguage}
+                      onChange={(e) => onLanguageChange(e.target.value as SupportedLanguage)}
+                      className="language-select"
+                    >
+                      {Object.values(supportedLanguages).map((lang) => (
+                        <option key={lang.code} value={lang.code}>
+                          {lang.flag} {lang.nativeName}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="dropdown-separator" />
+                </>
+              )}
               <button onClick={() => { handleSignOutClick(); }} className="btn-standard btn-small">
                 <FormattedMessage id="logout" />
               </button>

--- a/ui/src/game.tsx
+++ b/ui/src/game.tsx
@@ -3,6 +3,7 @@ import { generateClient } from "aws-amplify/api";
 import { Game, PlayerSheetSummary, Subscription as GQLSubscription, SheetSection, GameSummary } from "../../appsync/graphql";
 import { getGameQuery, updatedPlayerSubscription, updatedSectionSubscription, updatedGameSubscription } from "../../appsync/schema";
 import { FormattedMessage, useIntl, IntlShape } from 'react-intl';
+import { type SupportedLanguage } from './translations';
 import { GraphQLResult, GraphQLSubscription, GraphqlSubscriptionResult } from "@aws-amplify/api-graphql";
 import { TopBar } from "./frame";
 import { fetchUserAttributes } from 'aws-amplify/auth';
@@ -287,7 +288,12 @@ const useGameUpdates = (
 };
 
 // Main Game component
-const GameContent: React.FC<{ id: string, userEmail: string }> = ({ id, userEmail }) => {
+const GameContent: React.FC<{ 
+  id: string; 
+  userEmail: string;
+  currentLanguage?: SupportedLanguage;
+  onLanguageChange?: (language: SupportedLanguage) => void;
+}> = ({ id, userEmail, currentLanguage, onLanguageChange }) => {
   const [game, setGame] = useState<Game | null>(null);
   const [activeSheet, setActiveSheet] = useState<string | null>(null);
   const [userSubject, setUserSubject] = useState<string>("");
@@ -364,6 +370,8 @@ const GameContent: React.FC<{ id: string, userEmail: string }> = ({ id, userEmai
         isFirefly={userSubject === game.fireflyUserId}
         onEditGame={() => setShowEditModal(true)}
         onShareGame={() => setShowJoinCodeModal(true)}
+        currentLanguage={currentLanguage}
+        onLanguageChange={onLanguageChange}
       />
       <div className="tab-bar" role="tablist" aria-label={intl.formatMessage({ id: 'game.characterTabs' })}>
         {game.playerSheets
@@ -424,7 +432,12 @@ const GameContent: React.FC<{ id: string, userEmail: string }> = ({ id, userEmai
   );
 };
 
-const AppGame: React.FC<{ id: string, userEmail: string }> = (props) => (
+const AppGame: React.FC<{ 
+  id: string; 
+  userEmail: string;
+  currentLanguage?: SupportedLanguage;
+  onLanguageChange?: (language: SupportedLanguage) => void;
+}> = (props) => (
   <GameContent {...props} />
 );
 

--- a/ui/src/gamesMenu.tsx
+++ b/ui/src/gamesMenu.tsx
@@ -4,13 +4,18 @@ import { createGameMutation, getGamesQuery } from "../../appsync/schema";
 import { PlayerSheetSummary, CreateGameInput, Game } from "../../appsync/graphql";
 import { GraphQLResult } from "@aws-amplify/api-graphql";
 import { FormattedMessage, useIntl } from 'react-intl';
+import { type SupportedLanguage } from './translations';
 import { TopBar } from "./frame";
 import ReactMarkdown from 'react-markdown';
 import { SectionItemDescription } from './components/SectionItem';
 import { fetchAuthSession } from 'aws-amplify/auth';
 import { GameTypes, DefaultNewGameType } from "../../graphql/lib/constants/gameTypes";
 
-export const GamesMenuContent: React.FC<{ userEmail: string}> = ({ userEmail }) => {
+export const GamesMenuContent: React.FC<{ 
+    userEmail: string;
+    currentLanguage?: SupportedLanguage;
+    onLanguageChange?: (language: SupportedLanguage) => void;
+}> = ({ userEmail, currentLanguage, onLanguageChange }) => {
     const client = generateClient();
     const [games, setGames] = useState<PlayerSheetSummary[]>([]);
     const [error, setError] = useState<string | null>(null);
@@ -80,7 +85,14 @@ export const GamesMenuContent: React.FC<{ userEmail: string}> = ({ userEmail }) 
 
     return (
         <div className="gameslist">
-            <TopBar title={intl.formatMessage({ id: 'wildsea' })} userEmail={ userEmail } gameDescription="" isFirefly={false}/>
+            <TopBar 
+                title={intl.formatMessage({ id: 'wildsea' })} 
+                userEmail={userEmail} 
+                gameDescription="" 
+                isFirefly={false}
+                currentLanguage={currentLanguage}
+                onLanguageChange={onLanguageChange}
+            />
             <div className="allgames">
                 <section className="joingame" role="region" aria-labelledby="available-games-heading">
                     <h2 id="available-games-heading"><FormattedMessage id="availableGames" /></h2>
@@ -205,7 +217,11 @@ export const GamesMenuContent: React.FC<{ userEmail: string}> = ({ userEmail }) 
     );
 };
 
-export const GamesMenu: React.FC<{ userEmail: string }> = (props) => (
+export const GamesMenu: React.FC<{ 
+    userEmail: string;
+    currentLanguage?: SupportedLanguage;
+    onLanguageChange?: (language: SupportedLanguage) => void;
+}> = (props) => (
     <GamesMenuContent {...props} />
 );
 

--- a/ui/src/translations.en.ts
+++ b/ui/src/translations.en.ts
@@ -29,6 +29,7 @@ export const messagesEnglish = {
     'loading': 'Loading...',
     'login': 'Login',
     'logout': 'Logout',
+    'language': 'Language',
     'loadingGamesMenu': 'Loading games menu...',
     'errorFetchingGameData': 'Error fetching game data',
     'error': 'Error',
@@ -41,6 +42,7 @@ export const messagesEnglish = {
     'noGame': 'This game does not exist, or you are not a player in it.',
     'createGamePermissionDenied': 'You cannot create new games.',
     'errorCheckingPermissions': 'Failed to get permissions information.',
+    'errorUpdatingLanguage': 'Error updating language settings.',
 
     'gameType.wildsea.name': 'Wildsea',
     'gameType.deltaGreen.name': 'Delta Green',

--- a/ui/src/translations.tlh.ts
+++ b/ui/src/translations.tlh.ts
@@ -29,6 +29,7 @@ export const messagesKlingon = {
     'loading': 'DIch...',
     'login': 'naDev',
     'logout': 'DIch mI\'',
+    'language': 'Hol',
     'loadingGamesMenu': 'DIch Dub naDev DIch menu...',
     'errorFetchingGameData': 'DIch Dub DIch naDev DIch',
     'error': 'DIch',
@@ -41,6 +42,7 @@ export const messagesKlingon = {
     'noGame': 'DIch Dub DIch pagh, DIch DIch lo\'wI\' DIch.',
     'createGamePermissionDenied': 'DIch Dub chenmoH DIch DIch.',
     'errorCheckingPermissions': 'DIch DIch naDev DIch.',
+    'errorUpdatingLanguage': 'Hol choq DIch DIch.',
 
     'gameType.wildsea.name': 'yoD DIch',
     'gameType.deltaGreen.name': 'Delta DIch',

--- a/ui/src/translations.ts
+++ b/ui/src/translations.ts
@@ -19,7 +19,7 @@ export const supportedLanguages = {
   en: {
     code: 'en',
     name: 'English',
-    flag: '🇺🇸',
+    flag: '🇬🇧',
     nativeName: 'English',
   },
   tlh: {


### PR DESCRIPTION
## Summary
Adds a language selector dropdown to the user menu in the TopBar, allowing users to change their language preference which is saved to their user settings.

## Changes
- **Language Selector UI**: Added dropdown in TopBar user menu with flag emojis and native language names
- **Settings Integration**: Language changes are saved to user settings via GraphQL mutation and reflected in real-time
- **Component Architecture**: Pass language props through component hierarchy (main.tsx → GamesMenu/AppGame → TopBar)
- **User Experience**: Smooth language switching without page reloads, defaults to English when no language is set
- **Visual Design**: Added separator between language selector and logout button, proper alignment and spacing
- **Responsive Layout**: Set minimum dropdown width to 200px to prevent language name truncation
- **Localization**: Added translation keys for language selector in English and Klingon
- **Flag Selection**: Use UK flag (🇬🇧) for English instead of US flag

## Technical Implementation
- Language changes update user settings via `updateUserSettingsMutation`
- Real-time updates via `updatedUserSettingsSubscription`
- Smooth UI updates without `IntlProvider` key prop that was causing page reloads
- Consistent CSS styling matching existing dropdown button design

## UI Preview
The dropdown now shows:
```
🇬🇧 English
🖖 tlhIngan Hol
```

With a visual separator above the logout button for better organization.

🤖 Generated with [Claude Code](https://claude.ai/code)