### PR TITLE
Add user email address display to dropdown menu

### DIFF
--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -464,6 +464,28 @@ body {
   margin: var(--space-sm) 0;
 }
 
+.user-info {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-sm);
+}
+
+.user-avatar-small {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.user-email {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .language-selector {
   margin-bottom: var(--space-sm);
 }

--- a/ui/src/frame.tsx
+++ b/ui/src/frame.tsx
@@ -101,6 +101,11 @@ export const TopBar: React.FC<TopBarProps> = ({ title, userEmail, gameDescriptio
           </button>
           {showDropdown && (
             <div className="dropdown">
+              <div className="user-info">
+                <img src={gravatarUrl} alt="User avatar" className="user-avatar-small" />
+                <span className="user-email">{userEmail}</span>
+              </div>
+              <div className="dropdown-separator" />
               {onLanguageChange && (
                 <>
                   <div className="language-selector">


### PR DESCRIPTION
## Summary
- Add user email address with small avatar icon at the top of the user dropdown menu
- Display email with consistent styling and typography matching existing design
- Include text overflow handling with ellipsis for long email addresses
- Position at top of dropdown before existing content (language selector and logout)

## Test plan
- [x] Open user dropdown menu by clicking avatar
- [x] Verify user email appears at top with small avatar icon
- [x] Verify proper spacing and visual hierarchy
- [x] Test with long email addresses to ensure text overflow works
- [x] Verify existing dropdown functionality still works (language selector, logout)

Fixes #870

🤖 Generated with [Claude Code](https://claude.ai/code)