### PR TITLE
Fix HTML lang attribute to reflect selected language

### DIFF
--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -176,6 +176,11 @@ function AppWithIntl() {
     // Resolve the actual language to use (handling auto-detect)
     const actualLanguage = resolveLanguage(currentLanguage);
     
+    // Update HTML lang attribute when language changes
+    useEffect(() => {
+        document.documentElement.lang = actualLanguage;
+    }, [actualLanguage]);
+    
     // For non-standard locales like Klingon, use 'en' as the locale but keep our custom messages
     const localeForIntl = actualLanguage === 'tlh' ? 'en' : actualLanguage;
 


### PR DESCRIPTION
## Summary
- Add useEffect hook to dynamically update HTML lang attribute when language changes
- HTML lang attribute now properly reflects the actual language being used
- Previously was always hardcoded to "en" regardless of selected language

## Technical Details
- Updates `document.documentElement.lang` when `actualLanguage` changes
- Works with all language selection methods: auto-detection, user dropdown selection, and saved user settings
- Supports all language codes including custom ones like Klingon ('tlh')

## Test plan
- [x] Verify HTML lang attribute starts as "en" on initial load
- [x] Change language via dropdown and verify lang attribute updates
- [x] Test with auto-detection setting
- [x] Verify accessibility and SEO compliance improvements

## Accessibility Impact
This fix improves accessibility for screen readers and other assistive technologies by correctly identifying the page language, and improves SEO by providing proper language metadata.

Fixes #883

🤖 Generated with [Claude Code](https://claude.ai/code)