### PR TITLE
Add language-specific Delta Green derived attributes seed data

### DIFF
--- a/terraform/module/wildsea/templates.tf
+++ b/terraform/module/wildsea/templates.tf
@@ -278,33 +278,12 @@ resource "aws_dynamodb_table_item" "template_deltagreen_basic" {
           content = jsonencode({
             showEmpty = false
             items = [
-              {
-                id            = "hp-item"
-                name          = "Hit Points (HP)"
+              for derived in local.delta_green_derived : {
+                id            = "${lower(derived.attributeType)}-item"
+                name          = derived.name
                 description   = ""
-                attributeType = "HP"
-                current       = 10
-              },
-              {
-                id            = "wp-item"
-                name          = "Willpower Points (WP)"
-                description   = ""
-                attributeType = "WP"
-                current       = 10
-              },
-              {
-                id            = "san-item"
-                name          = "Sanity Points (SAN)"
-                description   = ""
-                attributeType = "SAN"
-                current       = 50
-              },
-              {
-                id            = "bp-item"
-                name          = "Breaking Point (BP)"
-                description   = ""
-                attributeType = "BP"
-                current       = 40
+                attributeType = derived.attributeType
+                current       = derived.defaultCurrent
               }
             ]
           })
@@ -486,6 +465,7 @@ resource "aws_dynamodb_table_item" "template_deltagreen_basic" {
 }
 
 locals {
-  delta_green_skills = jsondecode(file("${path.module}/../../../ui/src/seed/deltaGreenSkills.en.json"))
-  delta_green_stats  = jsondecode(file("${path.module}/../../../ui/src/seed/deltaGreenStats.en.json"))
+  delta_green_skills  = jsondecode(file("${path.module}/../../../ui/src/seed/deltaGreenSkills.en.json"))
+  delta_green_stats   = jsondecode(file("${path.module}/../../../ui/src/seed/deltaGreenStats.en.json"))
+  delta_green_derived = jsondecode(file("${path.module}/../../../ui/src/seed/deltaGreenDerived.en.json"))
 }

--- a/ui/src/sectionRegistry.tsx
+++ b/ui/src/sectionRegistry.tsx
@@ -22,7 +22,7 @@ const sectionRegistry: Record<string, SectionTypeConfig> = {
   'KEYVALUE': { component: SectionKeyValue, label: 'sectionType.keyvalue', seed: () => ({showEmpty: false, items: []}) },
   'RICHTEXT': { component: SectionRichText, label: 'sectionType.richtext', seed: () => ({items: [{content: ""}]}) },
   'DELTAGREENSTATS': { component: SectionDeltaGreenStats, label: 'sectionType.deltagreenstats', seed: (sheet, language) => createDefaultDeltaGreenStatsContent(language) },
-  'DELTAGREENDERED': { component: SectionDeltaGreenDerived, label: 'sectionType.deltagreendered', seed: (sheet) => createDefaultDeltaGreenDerivedContent(sheet) },
+  'DELTAGREENDERED': { component: SectionDeltaGreenDerived, label: 'sectionType.deltagreendered', seed: (sheet, language) => createDefaultDeltaGreenDerivedContent(sheet, language) },
   'DELTAGREENSKILLS': { component: SectionDeltaGreenSkills, label: 'sectionType.deltagreenskills', seed: (sheet, language) => createDefaultDeltaGreenSkillsContent(language) }
 };
 

--- a/ui/src/seed/deltaGreenDerived.en.json
+++ b/ui/src/seed/deltaGreenDerived.en.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "Hit Points (HP)",
+    "attributeType": "HP",
+    "defaultCurrent": 10
+  },
+  {
+    "name": "Willpower Points (WP)",
+    "attributeType": "WP",
+    "defaultCurrent": 10
+  },
+  {
+    "name": "Sanity Points (SAN)",
+    "attributeType": "SAN",
+    "defaultCurrent": 50
+  },
+  {
+    "name": "Breaking Point (BP)",
+    "attributeType": "BP",
+    "defaultCurrent": 40
+  }
+]

--- a/ui/src/seed/deltaGreenDerived.tlh.json
+++ b/ui/src/seed/deltaGreenDerived.tlh.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "yoD DIch (HP)",
+    "attributeType": "HP",
+    "defaultCurrent": 10
+  },
+  {
+    "name": "chup HoS (WP)",
+    "attributeType": "WP",
+    "defaultCurrent": 10
+  },
+  {
+    "name": "valwI' DIch (SAN)",
+    "attributeType": "SAN",
+    "defaultCurrent": 50
+  },
+  {
+    "name": "DIch nugh (BP)",
+    "attributeType": "BP",
+    "defaultCurrent": 40
+  }
+]

--- a/ui/src/seed/index.ts
+++ b/ui/src/seed/index.ts
@@ -3,6 +3,8 @@ import deltaGreenSkillsEn from './deltaGreenSkills.en.json';
 import deltaGreenSkillsTlh from './deltaGreenSkills.tlh.json';
 import deltaGreenStatsEn from './deltaGreenStats.en.json';
 import deltaGreenStatsTlh from './deltaGreenStats.tlh.json';
+import deltaGreenDerivedEn from './deltaGreenDerived.en.json';
+import deltaGreenDerivedTlh from './deltaGreenDerived.tlh.json';
 
 export interface DeltaGreenSkillSeed {
   name: string;
@@ -16,6 +18,12 @@ export interface DeltaGreenStatSeed {
   abbreviation: string;
 }
 
+export interface DeltaGreenDerivedSeed {
+  name: string;
+  attributeType: 'HP' | 'WP' | 'SAN' | 'BP';
+  defaultCurrent: number;
+}
+
 const deltaGreenSkillsSeeds: Record<Exclude<SupportedLanguage, 'auto'>, DeltaGreenSkillSeed[]> = {
   en: deltaGreenSkillsEn,
   tlh: deltaGreenSkillsTlh,
@@ -24,6 +32,11 @@ const deltaGreenSkillsSeeds: Record<Exclude<SupportedLanguage, 'auto'>, DeltaGre
 const deltaGreenStatsSeeds: Record<Exclude<SupportedLanguage, 'auto'>, DeltaGreenStatSeed[]> = {
   en: deltaGreenStatsEn,
   tlh: deltaGreenStatsTlh,
+};
+
+const deltaGreenDerivedSeeds: Record<Exclude<SupportedLanguage, 'auto'>, DeltaGreenDerivedSeed[]> = {
+  en: deltaGreenDerivedEn,
+  tlh: deltaGreenDerivedTlh,
 };
 
 export function getDeltaGreenSkillsSeed(language: SupportedLanguage): DeltaGreenSkillSeed[] {
@@ -40,4 +53,12 @@ export function getDeltaGreenStatsSeed(language: SupportedLanguage): DeltaGreenS
   }
   
   return deltaGreenStatsSeeds[language] || deltaGreenStatsSeeds.en;
+}
+
+export function getDeltaGreenDerivedSeed(language: SupportedLanguage): DeltaGreenDerivedSeed[] {
+  if (language === 'auto') {
+    return deltaGreenDerivedSeeds.en; // Default to English for auto-detect
+  }
+  
+  return deltaGreenDerivedSeeds[language] || deltaGreenDerivedSeeds.en;
 }


### PR DESCRIPTION
## Summary
- Add language-specific seed files for Delta Green derived attributes (HP, WP, SAN, BP)
- Include Klingon translations for derived attribute names
- Add TypeScript interface and getter function for type safety
- Update section creation to use language-aware seeds instead of hardcoded English
- Deduplicate Terraform template by using centralized seed data

## Test plan
- [x] UI tests pass
- [x] Terraform deployment successful
- [ ] Manual testing of language-specific derived attribute creation in UI

References #885

🤖 Generated with [Claude Code](https://claude.ai/code)