### PR TITLE
Add multilingual character templates for auto-populate feature

### DIFF
--- a/terraform/module/wildsea/templates.en.tf
+++ b/terraform/module/wildsea/templates.en.tf
@@ -1,0 +1,471 @@
+# Character templates for auto-populate feature
+resource "aws_dynamodb_table_item" "template_wildsea_basic_en" {
+  table_name = aws_dynamodb_table.table.name
+  hash_key   = aws_dynamodb_table.table.hash_key
+  range_key  = aws_dynamodb_table.table.range_key
+
+  item = jsonencode({
+    PK = {
+      S = "TEMPLATE#wildsea#en"
+    }
+    SK = {
+      S = "TEMPLATE#Basic Character"
+    }
+    templateName = {
+      S = "Basic Character"
+    }
+    displayName = {
+      S = "Basic Character"
+    }
+    gameType = {
+      S = "wildsea"
+    }
+    language = {
+      S = "en"
+    }
+    type = {
+      S = "TEMPLATE"
+    }
+    sections = {
+      S = jsonencode([
+        {
+          sectionName = "Character Details"
+          sectionType = "KEYVALUE"
+          content = jsonencode({
+            items = [
+              {
+                id          = "name"
+                name        = "Name"
+                description = ""
+              },
+              {
+                id          = "origin"
+                name        = "Origin"
+                description = ""
+              },
+              {
+                id          = "post"
+                name        = "Post"
+                description = ""
+              },
+              {
+                id          = "call"
+                name        = "Call"
+                description = ""
+              }
+            ]
+            showEmpty = true
+          })
+          position = 0
+        },
+        {
+          sectionName = "Edges"
+          sectionType = "TRACKABLE"
+          content = jsonencode({
+            items = [
+              {
+                id          = "iron"
+                name        = "Iron"
+                description = ""
+                current     = 2
+                maximum     = 5
+              },
+              {
+                id          = "teeth"
+                name        = "Teeth"
+                description = ""
+                current     = 2
+                maximum     = 5
+              },
+              {
+                id          = "veils"
+                name        = "Veils"
+                description = ""
+                current     = 2
+                maximum     = 5
+              }
+            ]
+            showEmpty = false
+          })
+          position = 1
+        },
+        {
+          sectionName = "Skills"
+          sectionType = "TRACKABLE"
+          content = jsonencode({
+            items = [
+              {
+                id          = "break"
+                name        = "Break"
+                description = ""
+                current     = 0
+                maximum     = 3
+              },
+              {
+                id          = "delve"
+                name        = "Delve"
+                description = ""
+                current     = 0
+                maximum     = 3
+              },
+              {
+                id          = "hunt"
+                name        = "Hunt"
+                description = ""
+                current     = 0
+                maximum     = 3
+              },
+              {
+                id          = "outwit"
+                name        = "Outwit"
+                description = ""
+                current     = 0
+                maximum     = 3
+              },
+              {
+                id          = "study"
+                name        = "Study"
+                description = ""
+                current     = 0
+                maximum     = 3
+              },
+              {
+                id          = "sway"
+                name        = "Sway"
+                description = ""
+                current     = 0
+                maximum     = 3
+              }
+            ]
+            showEmpty = false
+          })
+          position = 2
+        },
+        {
+          sectionName = "Resources"
+          sectionType = "BURNABLE"
+          content = jsonencode({
+            items = [
+              {
+                id          = "salvage"
+                name        = "Salvage"
+                description = ""
+                length      = 3
+                states      = ["unticked", "unticked", "unticked"]
+              },
+              {
+                id          = "specimens"
+                name        = "Specimens"
+                description = ""
+                length      = 3
+                states      = ["unticked", "unticked", "unticked"]
+              },
+              {
+                id          = "whispers"
+                name        = "Whispers"
+                description = ""
+                length      = 3
+                states      = ["unticked", "unticked", "unticked"]
+              },
+              {
+                id          = "charts"
+                name        = "Charts"
+                description = ""
+                length      = 3
+                states      = ["unticked", "unticked", "unticked"]
+              }
+            ]
+            showEmpty = false
+          })
+          position = 3
+        }
+      ])
+    }
+  })
+}
+
+# Delta Green Basic Character Template
+resource "aws_dynamodb_table_item" "template_deltagreen_basic_en" {
+  table_name = aws_dynamodb_table.table.name
+  hash_key   = aws_dynamodb_table.table.hash_key
+  range_key  = aws_dynamodb_table.table.range_key
+
+  item = jsonencode({
+    PK = {
+      S = "TEMPLATE#deltaGreen#en"
+    }
+    SK = {
+      S = "TEMPLATE#Basic Agent"
+    }
+    templateName = {
+      S = "Basic Agent"
+    }
+    displayName = {
+      S = "Basic Agent"
+    }
+    gameType = {
+      S = "deltaGreen"
+    }
+    language = {
+      S = "en"
+    }
+    type = {
+      S = "TEMPLATE"
+    }
+    sections = {
+      S = jsonencode([
+        {
+          sectionName = "Personal Data"
+          sectionType = "KEYVALUE"
+          content = jsonencode({
+            items = [
+              {
+                id          = "profession"
+                name        = "Profession"
+                description = ""
+              },
+              {
+                id          = "employer"
+                name        = "Employer"
+                description = ""
+              },
+              {
+                id          = "nationality"
+                name        = "Nationality"
+                description = ""
+              },
+              {
+                id          = "gender",
+                name        = "Gender"
+                description = ""
+              },
+              {
+                id          = "age",
+                name        = "Age and D.O.B."
+                description = ""
+              },
+              {
+                id          = "education",
+                name        = "Education and Occupational History",
+                description = ""
+              },
+            ]
+            showEmpty = true
+          })
+          position = 0
+        },
+        {
+          sectionName = "Statistics"
+          sectionType = "DELTAGREENSTATS"
+          content = jsonencode({
+            showEmpty = false
+            items = [
+              for stat in local.delta_green_stats : {
+                id                     = "stat-${lower(stat.abbreviation)}"
+                name                   = stat.name
+                description            = ""
+                score                  = 10
+                distinguishingFeatures = ""
+                abbreviation           = stat.abbreviation
+              }
+            ]
+          })
+          position = 1
+        },
+        {
+          sectionName = "Derived Attributes"
+          sectionType = "DELTAGREENDERED"
+          content = jsonencode({
+            showEmpty = false
+            items = [
+              for derived in local.delta_green_derived : {
+                id            = "${lower(derived.attributeType)}-item"
+                name          = derived.name
+                description   = ""
+                attributeType = derived.attributeType
+                current       = derived.defaultCurrent
+              }
+            ]
+          })
+          position = 2
+        },
+        {
+          sectionName = "Skills"
+          sectionType = "DELTAGREENSKILLS"
+          content = jsonencode({
+            showEmpty = false
+            items = [
+              for skill in local.delta_green_skills : {
+                id          = "skill-${replace(lower(skill.name), " ", "-")}"
+                name        = skill.name
+                description = lookup(skill, "description", "")
+                roll        = skill.roll
+                used        = false
+                hasUsedFlag = lookup(skill, "hasUsedFlag", true)
+              }
+            ]
+          })
+          position = 3
+        },
+        {
+          sectionName = "Bonds"
+          sectionType = "RICHTEXT"
+          content = jsonencode({
+            items = [
+              {
+                id          = "bonds"
+                name        = "Bonds"
+                description = ""
+                markdown    = "Add your bonds here"
+              }
+            ]
+            showEmpty = false
+          })
+          position = 4
+        },
+        {
+          sectionName = "Motivations and Mental Disorders"
+          sectionType = "RICHTEXT"
+          content = jsonencode({
+            items = [
+              {
+                id          = "motivations"
+                name        = "Motivations and Mental Disorders"
+                description = ""
+                markdown    = "None"
+              }
+            ]
+            showEmpty = false
+          })
+          position = 5
+        },
+        {
+          sectionName = "Incidents of SAN loss without going insane"
+          sectionType = "TRACKABLE"
+          content = jsonencode({
+            items = [
+              {
+                id          = "violence"
+                name        = "Violence"
+                description = ""
+                length      = 3
+                ticked      = 0
+              },
+              {
+                id          = "helplessness"
+                name        = "Helplessness"
+                description = ""
+                length      = 3
+                ticked      = 0
+              }
+            ]
+            showEmpty = true
+          })
+          position = 6
+        },
+        {
+          sectionName = "Wounds and Ailments"
+          sectionType = "RICHTEXT"
+          content = jsonencode({
+            items = [
+              {
+                id          = "wounds"
+                name        = "Wounds and Ailments"
+                description = ""
+                markdown    = "None"
+              }
+            ]
+            showEmpty = false
+          })
+          position = 7
+        },
+        {
+          sectionName = "Armor and Gear"
+          sectionType = "RICHTEXT"
+          content = jsonencode({
+            items = [
+              {
+                id          = "armor"
+                name        = "Armor and Gear"
+                description = ""
+                markdown    = "None"
+              }
+            ]
+            showEmpty = false
+          })
+          position = 8
+        },
+        {
+          sectionName = "Weapons"
+          sectionType = "RICHTEXT"
+          content = jsonencode({
+            items = [
+              {
+                id          = "weapons"
+                name        = "Weapons"
+                description = ""
+                markdown    = "None"
+              }
+            ]
+            showEmpty = false
+          })
+          position = 9
+        },
+        {
+          sectionName = "Personal Details and Notes"
+          sectionType = "RICHTEXT"
+          content = jsonencode({
+            items = [
+              {
+                id          = "personal"
+                name        = "Personal Details and Notes"
+                description = ""
+                markdown    = "Describe your character here"
+              }
+            ]
+            showEmpty = false
+          })
+          position = 10
+        },
+        {
+          sectionName = "Developments which affect Home and Family"
+          sectionType = "RICHTEXT"
+          content = jsonencode({
+            items = [
+              {
+                id          = "family"
+                name        = "Developments which affect Home and Family"
+                description = ""
+                markdown    = "None"
+              }
+            ]
+            showEmpty = false
+          })
+          position = 11
+        },
+        {
+          sectionName = "Special Training"
+          sectionType = "RICHTEXT"
+          content = jsonencode({
+            items = [
+              {
+                id          = "training"
+                name        = "Special Training"
+                description = ""
+                markdown    = "None"
+              }
+            ]
+            showEmpty = false
+          })
+          position = 12
+        }
+      ])
+    }
+  })
+}
+
+locals {
+  delta_green_skills  = jsondecode(file("${path.module}/../../../ui/src/seed/deltaGreenSkills.en.json"))
+  delta_green_stats   = jsondecode(file("${path.module}/../../../ui/src/seed/deltaGreenStats.en.json"))
+  delta_green_derived = jsondecode(file("${path.module}/../../../ui/src/seed/deltaGreenDerived.en.json"))
+}

--- a/terraform/module/wildsea/templates.tlh.tf
+++ b/terraform/module/wildsea/templates.tlh.tf
@@ -1,27 +1,27 @@
-# Character templates for auto-populate feature
-resource "aws_dynamodb_table_item" "template_wildsea_basic" {
+# Character templates for auto-populate feature - Klingon (tlh)
+resource "aws_dynamodb_table_item" "template_wildsea_basic_tlh" {
   table_name = aws_dynamodb_table.table.name
   hash_key   = aws_dynamodb_table.table.hash_key
   range_key  = aws_dynamodb_table.table.range_key
 
   item = jsonencode({
     PK = {
-      S = "TEMPLATE#wildsea#en"
+      S = "TEMPLATE#wildsea#tlh"
     }
     SK = {
-      S = "TEMPLATE#Basic Character"
+      S = "TEMPLATE#motlhbe' jup"
     }
     templateName = {
-      S = "Basic Character"
+      S = "motlhbe' jup"
     }
     displayName = {
-      S = "Basic Character"
+      S = "motlhbe' jup"
     }
     gameType = {
       S = "wildsea"
     }
     language = {
-      S = "en"
+      S = "tlh"
     }
     type = {
       S = "TEMPLATE"
@@ -29,28 +29,28 @@ resource "aws_dynamodb_table_item" "template_wildsea_basic" {
     sections = {
       S = jsonencode([
         {
-          sectionName = "Character Details"
+          sectionName = "jup nav"
           sectionType = "KEYVALUE"
           content = jsonencode({
             items = [
               {
                 id          = "name"
-                name        = "Name"
+                name        = "pagh"
                 description = ""
               },
               {
                 id          = "origin"
-                name        = "Origin"
+                name        = "mI'"
                 description = ""
               },
               {
                 id          = "post"
-                name        = "Post"
+                name        = "Daq"
                 description = ""
               },
               {
                 id          = "call"
-                name        = "Call"
+                name        = "DIch"
                 description = ""
               }
             ]
@@ -59,27 +59,27 @@ resource "aws_dynamodb_table_item" "template_wildsea_basic" {
           position = 0
         },
         {
-          sectionName = "Edges"
+          sectionName = "jup"
           sectionType = "TRACKABLE"
           content = jsonencode({
             items = [
               {
                 id          = "iron"
-                name        = "Iron"
+                name        = "baS"
                 description = ""
                 current     = 2
                 maximum     = 5
               },
               {
                 id          = "teeth"
-                name        = "Teeth"
+                name        = "DIrgh"
                 description = ""
                 current     = 2
                 maximum     = 5
               },
               {
                 id          = "veils"
-                name        = "Veils"
+                name        = "Sor"
                 description = ""
                 current     = 2
                 maximum     = 5
@@ -90,48 +90,48 @@ resource "aws_dynamodb_table_item" "template_wildsea_basic" {
           position = 1
         },
         {
-          sectionName = "Skills"
+          sectionName = "nugh"
           sectionType = "TRACKABLE"
           content = jsonencode({
             items = [
               {
                 id          = "break"
-                name        = "Break"
+                name        = "DIch"
                 description = ""
                 current     = 0
                 maximum     = 3
               },
               {
                 id          = "delve"
-                name        = "Delve"
+                name        = "nej"
                 description = ""
                 current     = 0
                 maximum     = 3
               },
               {
                 id          = "hunt"
-                name        = "Hunt"
+                name        = "DIch"
                 description = ""
                 current     = 0
                 maximum     = 3
               },
               {
                 id          = "outwit"
-                name        = "Outwit"
+                name        = "val"
                 description = ""
                 current     = 0
                 maximum     = 3
               },
               {
                 id          = "study"
-                name        = "Study"
+                name        = "ghoj"
                 description = ""
                 current     = 0
                 maximum     = 3
               },
               {
                 id          = "sway"
-                name        = "Sway"
+                name        = "DIch"
                 description = ""
                 current     = 0
                 maximum     = 3
@@ -142,34 +142,34 @@ resource "aws_dynamodb_table_item" "template_wildsea_basic" {
           position = 2
         },
         {
-          sectionName = "Resources"
+          sectionName = "nugh"
           sectionType = "BURNABLE"
           content = jsonencode({
             items = [
               {
                 id          = "salvage"
-                name        = "Salvage"
+                name        = "choq"
                 description = ""
                 length      = 3
                 states      = ["unticked", "unticked", "unticked"]
               },
               {
                 id          = "specimens"
-                name        = "Specimens"
+                name        = "naDev"
                 description = ""
                 length      = 3
                 states      = ["unticked", "unticked", "unticked"]
               },
               {
                 id          = "whispers"
-                name        = "Whispers"
+                name        = "jach"
                 description = ""
                 length      = 3
                 states      = ["unticked", "unticked", "unticked"]
               },
               {
                 id          = "charts"
-                name        = "Charts"
+                name        = "pu'jIn"
                 description = ""
                 length      = 3
                 states      = ["unticked", "unticked", "unticked"]
@@ -184,30 +184,30 @@ resource "aws_dynamodb_table_item" "template_wildsea_basic" {
   })
 }
 
-# Delta Green Basic Character Template
-resource "aws_dynamodb_table_item" "template_deltagreen_basic" {
+# Delta Green Basic Character Template - Klingon (tlh)
+resource "aws_dynamodb_table_item" "template_deltagreen_basic_tlh" {
   table_name = aws_dynamodb_table.table.name
   hash_key   = aws_dynamodb_table.table.hash_key
   range_key  = aws_dynamodb_table.table.range_key
 
   item = jsonencode({
     PK = {
-      S = "TEMPLATE#deltaGreen#en"
+      S = "TEMPLATE#deltaGreen#tlh"
     }
     SK = {
-      S = "TEMPLATE#Basic Agent"
+      S = "TEMPLATE#motlhbe' jup"
     }
     templateName = {
-      S = "Basic Agent"
+      S = "motlhbe' jup"
     }
     displayName = {
-      S = "Basic Agent"
+      S = "motlhbe' jup"
     }
     gameType = {
       S = "deltaGreen"
     }
     language = {
-      S = "en"
+      S = "tlh"
     }
     type = {
       S = "TEMPLATE"
@@ -215,38 +215,38 @@ resource "aws_dynamodb_table_item" "template_deltagreen_basic" {
     sections = {
       S = jsonencode([
         {
-          sectionName = "Personal Data"
+          sectionName = "nugh naDev"
           sectionType = "KEYVALUE"
           content = jsonencode({
             items = [
               {
                 id          = "profession"
-                name        = "Profession"
+                name        = "DIlo'"
                 description = ""
               },
               {
                 id          = "employer"
-                name        = "Employer"
+                name        = "DIch"
                 description = ""
               },
               {
                 id          = "nationality"
-                name        = "Nationality"
+                name        = "Hol"
                 description = ""
               },
               {
                 id          = "gender",
-                name        = "Gender"
+                name        = "DIch"
                 description = ""
               },
               {
                 id          = "age",
-                name        = "Age and D.O.B."
+                name        = "DIch 'ej jup"
                 description = ""
               },
               {
                 id          = "education",
-                name        = "Education and Occupational History",
+                name        = "ghojmeH mI' 'ej DIlo' mI'",
                 description = ""
               },
             ]
@@ -255,12 +255,12 @@ resource "aws_dynamodb_table_item" "template_deltagreen_basic" {
           position = 0
         },
         {
-          sectionName = "Statistics"
+          sectionName = "naDev"
           sectionType = "DELTAGREENSTATS"
           content = jsonencode({
             showEmpty = false
             items = [
-              for stat in local.delta_green_stats : {
+              for stat in local.delta_green_stats_tlh : {
                 id                     = "stat-${lower(stat.abbreviation)}"
                 name                   = stat.name
                 description            = ""
@@ -273,12 +273,12 @@ resource "aws_dynamodb_table_item" "template_deltagreen_basic" {
           position = 1
         },
         {
-          sectionName = "Derived Attributes"
+          sectionName = "chenmoH naDev"
           sectionType = "DELTAGREENDERED"
           content = jsonencode({
             showEmpty = false
             items = [
-              for derived in local.delta_green_derived : {
+              for derived in local.delta_green_derived_tlh : {
                 id            = "${lower(derived.attributeType)}-item"
                 name          = derived.name
                 description   = ""
@@ -290,12 +290,12 @@ resource "aws_dynamodb_table_item" "template_deltagreen_basic" {
           position = 2
         },
         {
-          sectionName = "Skills"
+          sectionName = "nugh"
           sectionType = "DELTAGREENSKILLS"
           content = jsonencode({
             showEmpty = false
             items = [
-              for skill in local.delta_green_skills : {
+              for skill in local.delta_green_skills_tlh : {
                 id          = "skill-${replace(lower(skill.name), " ", "-")}"
                 name        = skill.name
                 description = lookup(skill, "description", "")
@@ -308,15 +308,15 @@ resource "aws_dynamodb_table_item" "template_deltagreen_basic" {
           position = 3
         },
         {
-          sectionName = "Bonds"
+          sectionName = "jup"
           sectionType = "RICHTEXT"
           content = jsonencode({
             items = [
               {
                 id          = "bonds"
-                name        = "Bonds"
+                name        = "jup"
                 description = ""
-                markdown    = "Add your bonds here"
+                markdown    = "naDev chel"
               }
             ]
             showEmpty = false
@@ -324,15 +324,15 @@ resource "aws_dynamodb_table_item" "template_deltagreen_basic" {
           position = 4
         },
         {
-          sectionName = "Motivations and Mental Disorders"
+          sectionName = "nugh 'ej valwI' DIch"
           sectionType = "RICHTEXT"
           content = jsonencode({
             items = [
               {
                 id          = "motivations"
-                name        = "Motivations and Mental Disorders"
+                name        = "nugh 'ej valwI' DIch"
                 description = ""
-                markdown    = "None"
+                markdown    = "pagh"
               }
             ]
             showEmpty = false
@@ -340,20 +340,20 @@ resource "aws_dynamodb_table_item" "template_deltagreen_basic" {
           position = 5
         },
         {
-          sectionName = "Incidents of SAN loss without going insane"
+          sectionName = "SAN Huj 'e' DIch"
           sectionType = "TRACKABLE"
           content = jsonencode({
             items = [
               {
                 id          = "violence"
-                name        = "Violence"
+                name        = "HIv"
                 description = ""
                 length      = 3
                 ticked      = 0
               },
               {
                 id          = "helplessness"
-                name        = "Helplessness"
+                name        = "jagh"
                 description = ""
                 length      = 3
                 ticked      = 0
@@ -364,15 +364,15 @@ resource "aws_dynamodb_table_item" "template_deltagreen_basic" {
           position = 6
         },
         {
-          sectionName = "Wounds and Ailments"
+          sectionName = "DIch 'ej naDev"
           sectionType = "RICHTEXT"
           content = jsonencode({
             items = [
               {
                 id          = "wounds"
-                name        = "Wounds and Ailments"
+                name        = "DIch 'ej naDev"
                 description = ""
-                markdown    = "None"
+                markdown    = "pagh"
               }
             ]
             showEmpty = false
@@ -380,15 +380,15 @@ resource "aws_dynamodb_table_item" "template_deltagreen_basic" {
           position = 7
         },
         {
-          sectionName = "Armor and Gear"
+          sectionName = "So' 'ej nugh"
           sectionType = "RICHTEXT"
           content = jsonencode({
             items = [
               {
                 id          = "armor"
-                name        = "Armor and Gear"
+                name        = "So' 'ej nugh"
                 description = ""
-                markdown    = "None"
+                markdown    = "pagh"
               }
             ]
             showEmpty = false
@@ -396,15 +396,15 @@ resource "aws_dynamodb_table_item" "template_deltagreen_basic" {
           position = 8
         },
         {
-          sectionName = "Weapons"
+          sectionName = "nuH"
           sectionType = "RICHTEXT"
           content = jsonencode({
             items = [
               {
                 id          = "weapons"
-                name        = "Weapons"
+                name        = "nuH"
                 description = ""
-                markdown    = "None"
+                markdown    = "pagh"
               }
             ]
             showEmpty = false
@@ -412,15 +412,15 @@ resource "aws_dynamodb_table_item" "template_deltagreen_basic" {
           position = 9
         },
         {
-          sectionName = "Personal Details and Notes"
+          sectionName = "nugh naDev 'ej chup"
           sectionType = "RICHTEXT"
           content = jsonencode({
             items = [
               {
                 id          = "personal"
-                name        = "Personal Details and Notes"
+                name        = "nugh naDev 'ej chup"
                 description = ""
-                markdown    = "Describe your character here"
+                markdown    = "jup DIch"
               }
             ]
             showEmpty = false
@@ -428,15 +428,15 @@ resource "aws_dynamodb_table_item" "template_deltagreen_basic" {
           position = 10
         },
         {
-          sectionName = "Developments which affect Home and Family"
+          sectionName = "juH 'ej DIch DIch"
           sectionType = "RICHTEXT"
           content = jsonencode({
             items = [
               {
                 id          = "family"
-                name        = "Developments which affect Home and Family"
+                name        = "juH 'ej DIch DIch"
                 description = ""
-                markdown    = "None"
+                markdown    = "pagh"
               }
             ]
             showEmpty = false
@@ -444,15 +444,15 @@ resource "aws_dynamodb_table_item" "template_deltagreen_basic" {
           position = 11
         },
         {
-          sectionName = "Special Training"
+          sectionName = "nugh DIch"
           sectionType = "RICHTEXT"
           content = jsonencode({
             items = [
               {
                 id          = "training"
-                name        = "Special Training"
+                name        = "nugh DIch"
                 description = ""
-                markdown    = "None"
+                markdown    = "pagh"
               }
             ]
             showEmpty = false
@@ -465,7 +465,7 @@ resource "aws_dynamodb_table_item" "template_deltagreen_basic" {
 }
 
 locals {
-  delta_green_skills  = jsondecode(file("${path.module}/../../../ui/src/seed/deltaGreenSkills.en.json"))
-  delta_green_stats   = jsondecode(file("${path.module}/../../../ui/src/seed/deltaGreenStats.en.json"))
-  delta_green_derived = jsondecode(file("${path.module}/../../../ui/src/seed/deltaGreenDerived.en.json"))
+  delta_green_skills_tlh  = jsondecode(file("${path.module}/../../../ui/src/seed/deltaGreenSkills.tlh.json"))
+  delta_green_stats_tlh   = jsondecode(file("${path.module}/../../../ui/src/seed/deltaGreenStats.tlh.json"))
+  delta_green_derived_tlh = jsondecode(file("${path.module}/../../../ui/src/seed/deltaGreenDerived.tlh.json"))
 }

--- a/ui/src/playerSheetTab.tsx
+++ b/ui/src/playerSheetTab.tsx
@@ -269,6 +269,7 @@ export const PlayerSheetTab: React.FC<{ sheet: PlayerSheet, userSubject: string,
           gameType={game.gameType || 'wildsea'}
           gameId={sheet.gameId}
           userId={sheet.userId}
+          currentLanguage={currentLanguage}
           onSectionsAdded={() => {
             // The sections will be updated automatically via GraphQL subscriptions
             // so we don't need to do anything here


### PR DESCRIPTION
## Summary
- Split templates.tf into language-specific files (templates.en.tf, templates.tlh.tf)
- Create Klingon translations for Wildsea and Delta Green character templates
- Update auto-populate component to use language-aware template fetching
- Pass currentLanguage through component chain for proper language resolution
- Add fallback logic to use English templates when user's language isn't available

## Test plan
- [x] UI tests pass
- [x] Terraform deployment successful
- [x] Auto-populate dropdown works with fallback logic
- [ ] Manual testing of language-specific template selection in UI

References #885

🤖 Generated with [Claude Code](https://claude.ai/code)