### PR TITLE
Add language-specific character names for createGame (progress on #887)

### DIFF
--- a/appsync/graphql.ts
+++ b/appsync/graphql.ts
@@ -33,6 +33,7 @@ export type CharacterTemplateMetadata = {
 export type CreateGameInput = {
   description?: InputMaybe<Scalars['String']['input']>;
   gameType: Scalars['String']['input'];
+  language: Scalars['String']['input'];
   name: Scalars['String']['input'];
 };
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -67,6 +67,7 @@ input CreateGameInput {
     name: String!
     gameType: String!
     description: String
+    language: String!
 }
 
 input JoinGameInput {

--- a/graphql/tests/createGame.test.ts
+++ b/graphql/tests/createGame.test.ts
@@ -8,7 +8,7 @@ jest.mock("../lib/joinCode", () => ({
   generateJoinCode: jest.fn(() => "7A8CV2"),
 }));
 
-import { request, response } from "../mutation/createGame/createGame";
+import { request, response } from "../function/createGame/createGame";
 import {
   util,
   Context,
@@ -24,14 +24,24 @@ describe("request function", () => {
   it("should return a valid DynamoDBTransactWriteItem when context is valid", () => {
     // Arrange
     const mockContext: Context<{
-      input: { name: string; description?: string; gameType: string };
-    }> = {
+      input: {
+        name: string;
+        description?: string;
+        gameType: string;
+        language: string;
+      };
+    }> & {
+      stash: {
+        gameDefaults?: { defaultCharacterName: string; defaultGMName: string };
+      };
+    } = {
       env: {},
       arguments: {
         input: {
           name: "Test Game",
           description: "Test Description",
           gameType: "wildsea",
+          language: "en",
         },
       },
       args: {
@@ -39,6 +49,7 @@ describe("request function", () => {
           name: "Test Game",
           description: "Test Description",
           gameType: "wildsea",
+          language: "en",
         },
       },
       identity: {
@@ -54,7 +65,12 @@ describe("request function", () => {
         selectionSetGraphQL: "",
       } as Info,
       result: {},
-      stash: {},
+      stash: {
+        gameDefaults: {
+          defaultCharacterName: "Test Character",
+          defaultGMName: "Test Firefly",
+        },
+      },
       prev: undefined,
       request: {
         headers: {},
@@ -116,7 +132,7 @@ describe("request function", () => {
             createdAt: { S: mockTimestamp },
             updatedAt: { S: mockTimestamp },
             type: { S: "FIREFLY" },
-            characterName: { S: "Firefly" },
+            characterName: { S: "Test Firefly" },
           },
         },
         {
@@ -136,7 +152,7 @@ describe("request function", () => {
             createdAt: { S: mockTimestamp },
             updatedAt: { S: mockTimestamp },
             type: { S: "SHIP" },
-            characterName: { S: "Unnamed Ship" },
+            characterName: { S: "Test Character" },
           },
         },
       ],
@@ -146,14 +162,24 @@ describe("request function", () => {
   it("should throw an error if context identity is missing", () => {
     // Arrange
     const mockContext: Context<{
-      input: { name: string; description?: string; gameType: string };
-    }> = {
+      input: {
+        name: string;
+        description?: string;
+        gameType: string;
+        language: string;
+      };
+    }> & {
+      stash: {
+        gameDefaults?: { defaultCharacterName: string; defaultGMName: string };
+      };
+    } = {
       env: {},
       arguments: {
         input: {
           name: "Test Game",
           description: "Test Description",
           gameType: "wildsea",
+          language: "en",
         },
       },
       args: {
@@ -161,6 +187,7 @@ describe("request function", () => {
           name: "Test Game",
           description: "Test Description",
           gameType: "wildsea",
+          language: "en",
         },
       },
       identity: undefined,
@@ -174,7 +201,12 @@ describe("request function", () => {
         selectionSetGraphQL: "",
       } as Info,
       result: {},
-      stash: {},
+      stash: {
+        gameDefaults: {
+          defaultCharacterName: "Test Character",
+          defaultGMName: "Test Firefly",
+        },
+      },
       prev: undefined,
       request: {
         headers: {},
@@ -189,14 +221,24 @@ describe("request function", () => {
   it("should throw an error if user ID is missing", () => {
     // Arrange
     const mockContext: Context<{
-      input: { name: string; description?: string; gameType: string };
-    }> = {
+      input: {
+        name: string;
+        description?: string;
+        gameType: string;
+        language: string;
+      };
+    }> & {
+      stash: {
+        gameDefaults?: { defaultCharacterName: string; defaultGMName: string };
+      };
+    } = {
       env: {},
       arguments: {
         input: {
           name: "Test Game",
           description: "Test Description",
           gameType: "wildsea",
+          language: "en",
         },
       },
       args: {
@@ -204,6 +246,7 @@ describe("request function", () => {
           name: "Test Game",
           description: "Test Description",
           gameType: "wildsea",
+          language: "en",
         },
       },
       identity: {} as AppSyncIdentityCognito,
@@ -217,7 +260,12 @@ describe("request function", () => {
         selectionSetGraphQL: "",
       } as Info,
       result: {},
-      stash: {},
+      stash: {
+        gameDefaults: {
+          defaultCharacterName: "Test Character",
+          defaultGMName: "Test Firefly",
+        },
+      },
       prev: undefined,
       request: {
         headers: {},

--- a/terraform/module/wildsea/graphql.tf
+++ b/terraform/module/wildsea/graphql.tf
@@ -275,6 +275,10 @@ locals {
   resolvers = merge(local.mutations_map, local.queries_map, local.subscriptions_map)
 
   pipelines_map = {
+    createGame = {
+      type : "Mutation",
+      functions = ["getGameDefaults", "createGame"]
+    }
     joinGame = {
       type : "Mutation",
       functions = ["getGameWithToken", "getGameDefaults", "joinGame"]

--- a/ui/src/gamesMenu.tsx
+++ b/ui/src/gamesMenu.tsx
@@ -59,6 +59,7 @@ export const GamesMenuContent: React.FC<{
             name: gameName,
             gameType: gameType,
             description: gameDescription,
+            language: currentLanguage || 'en',
         };
 
         try {


### PR DESCRIPTION
## Summary
- Implement language-specific default character names for createGame functionality
- This builds on the previous joinGame language support, continuing progress on issue #887
- Convert createGame from direct resolver to pipeline resolver to leverage existing getGameDefaults function

## Changes Made
- ✅ Add language parameter to CreateGameInput in GraphQL schema
- ✅ Convert createGame to pipeline resolver using getGameDefaults function
- ✅ Move createGame from mutation/ to function/ directory for pipeline compatibility
- ✅ Update createGame function to use language-specific defaults from context.stash
- ✅ Update UI to pass user's language parameter based on locale
- ✅ Fix getGameDefaults to handle both joinGame and createGame pipeline contexts
- ✅ Add proper error handling and debugging for missing data
- ✅ Update all tests to support new pipeline structure and language parameter

## Technical Details
**Pipeline Architecture:**
- **createGame pipeline**: `getGameDefaults` → `createGame`
- **joinGame pipeline**: `getGameWithToken` → `getGameDefaults` → `joinGame`

**getGameDefaults Enhancement:**
- Handles gameType from `context.prev.result.gameType` (joinGame) or `context.arguments.input.gameType` (createGame)
- Supports both `JoinGameInput` and `CreateGameInput` parameter types
- Returns appropriate context for each pipeline scenario

## Test Plan
- [x] All existing GraphQL tests pass (64/64)
- [x] New createGame pipeline structure works correctly
- [x] Language fallback mechanism works: requested language → English → error handling
- [x] UI correctly passes language parameter from user locale
- [x] Deployed and tested in development environment
- [x] Both GM and NPC characters get language-specific names

## Database Integration
Leverages existing game defaults infrastructure:
- English (en): "Firefly"/"Unnamed Ship" → Klingon (tlh): "yoDwI'"/"motlhbe' jup"
- Same 3-tier fallback as joinGame implementation
- Reuses GAMEDEFAULTS database entries created in previous PR

## Progress on #887
This PR adds createGame language support to complement the existing joinGame support.
**Completed:** Both major game creation flows now support language-specific character names.
**Remaining:** Additional aspects of issue #887 may still need to be addressed.

🤖 Generated with [Claude Code](https://claude.ai/code)