### PR TITLE
Update CLAUDE.md documentation for database-driven theme system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,10 @@ The application uses a modular section system for character sheets:
 ### CSS and Styling
 
 - Global styles in `ui/public/style.css`
+- **Theme System**: Database-driven themes loaded dynamically via `ui/src/themeLoader.ts`
+  - Theme files located in `ui/public/themes/` (wildsea.css, deltaGreen.css, default.css)
+  - Themes are stored in GAMEDEFAULTS database records and loaded per game
+  - Use `loadTheme(themeName)` to dynamically load CSS themes
 - Uses CSS Grid for complex layouts (prefer over HTML tables)
 - Section items use grid layout that may need overrides: `.section-items .custom-grid { grid-column: 1 / -1; }`
 - Modern CSS patterns: `minmax()`, flexbox, grid for responsive design
@@ -144,11 +148,15 @@ The IAC roles and github setup:
 
 Code is stored in github, and issues are tracked there too.
 
-## Game Types
+## Game Types and Configuration
 
-The application supports multiple TTRPG systems with specific character types
-and default NPCs configured in `gameTypes.ts`. When adding new game support,
-update this configuration file.
+The application supports multiple TTRPG systems with database-driven configuration:
+
+- **Game Types**: Available via `getGameTypes` GraphQL query from GAMEDEFAULTS database records
+- **Game Configuration**: Character names, GM names, NPCs, and themes stored in database
+- **Adding New Games**: Update `terraform/module/wildsea/gamedefaults.tf` with new GAMEDEFAULTS entries
+- **Theme Assignment**: Each game type has a theme field that determines CSS theme loading
+- **No Hardcoded Lists**: All game type configuration is database-driven, not hardcoded in code
 
 ## Authentication
 


### PR DESCRIPTION
## Summary
- Update CLAUDE.md to document the new database-driven theme system implemented in PR #905
- Clarify that all game type configuration is now database-driven, not hardcoded
- Provide guidance for adding new game types via Terraform GAMEDEFAULTS

## Changes Made
- **CSS and Styling section**: Added comprehensive documentation of the database-driven theme system
- **Game Types section**: Completely rewrote to reflect database-driven approach and remove outdated references
- Documented theme file locations and `themeLoader.ts` usage
- Added guidance on adding new games via `terraform/module/wildsea/gamedefaults.tf`

## Context
This documentation update follows the completion of issue #900 in PR #905, which successfully moved CSS theme selection from hardcoded game types to database-driven configuration. This was the final step in eliminating all hardcoded game type lists from the codebase.

The documentation now accurately reflects the current architecture where:
- Game types are fetched via `getGameTypes` GraphQL query from database
- Themes are stored in GAMEDEFAULTS records and loaded dynamically
- All game configuration (names, NPCs, themes) comes from database, not code

🤖 Generated with [Claude Code](https://claude.ai/code)