### PR TITLE
Fix: Adding a section no longer puts character name into edit mode

### DIFF
--- a/ui/src/playerSheetTab.tsx
+++ b/ui/src/playerSheetTab.tsx
@@ -279,10 +279,7 @@ export const PlayerSheetTab: React.FC<{ sheet: PlayerSheet, userSubject: string,
 
       {mayEditSheet && !showNewSection && (
         <>
-          <button onClick={() => {
-            setShowNewSection(true);
-            setEditingSheetId(sheet.userId);
-          }} className="btn-standard btn-small">
+          <button onClick={() => setShowNewSection(true)} className="btn-standard btn-small">
             <FormattedMessage id="playerSheetTab.addSection" />
           </button>
           <button onClick={() => setShowDeleteSectionModal(true)} className="btn-danger btn-small">
@@ -291,7 +288,7 @@ export const PlayerSheetTab: React.FC<{ sheet: PlayerSheet, userSubject: string,
         </>
       )}
 
-      {mayEditSheet && showNewSection && editingSheetId === sheet.userId && (
+      {mayEditSheet && showNewSection && (
         <div className="new-section">
           <input
             id="new-section-name"


### PR DESCRIPTION
## Summary
- Remove unnecessary `setEditingSheetId` call when clicking Add Section button
- Remove redundant condition for showing new section form
- Character name edit mode is now independent of section creation

## Test plan
- [x] Click "Add Section" button and verify character name does not enter edit mode
- [x] Verify section creation form still appears correctly
- [x] Verify character name edit mode still works independently via the Edit button

Fixes #890

🤖 Generated with [Claude Code](https://claude.ai/code)