### PR TITLE
Fix missing 'gameDeleted' translation key

### DIFF
--- a/ui/src/translations.en.ts
+++ b/ui/src/translations.en.ts
@@ -83,6 +83,7 @@ export const messagesEnglish = {
     'deleteGameModal.warning': 'Here by Terrapex\'s! This action cannot be undone. All game data will be permanently deleted.',
     'deleteGameModal.understand': 'I understand that this action is permanent and cannot be undone.',
     'deleteGameModal.confirm': '🗑 Confirm Delete',
+    'gameDeleted': 'Game deleted successfully',
 
     'sectionName': 'Name',
     'save': '💾 Save Changes',

--- a/ui/src/translations.tlh.ts
+++ b/ui/src/translations.tlh.ts
@@ -83,6 +83,7 @@ export const messagesKlingon = {
     'deleteGameModal.warning': 'DIch Terrapex\'! DIch mI\' DIch choHbe\'meH. Hoch DIch Dub DIch nugh DIch.',
     'deleteGameModal.understand': 'DIch mI\' motlhbe\' \'e\' DIch choHbe\'meH DIch vIl.',
     'deleteGameModal.confirm': '🗑 DIch DIch',
+    'gameDeleted': 'DIch Dub DIch DIch',
 
     'sectionName': 'pagh',
     'save': '💾 choq DIch',


### PR DESCRIPTION
## Summary
- Fixed missing `gameDeleted` translation key that was causing formatjs MISSING_TRANSLATION error
- Added translation for English: "Game deleted successfully"
- Added translation for Klingon: "DIch Dub DIch DIch"

## Test plan
- [x] Verify translations are properly added to both language files
- [ ] Test game deletion flow in both languages to confirm toast message displays correctly
- [ ] Confirm no more MISSING_TRANSLATION errors for this key

Fixes #907

🤖 Generated with [Claude Code](https://claude.ai/code)