### PR TITLE
Improve GraphQL i18n system with value concatenation and proper fallbacks

### DIFF
--- a/graphql/function/createGame/createGame.ts
+++ b/graphql/function/createGame/createGame.ts
@@ -12,6 +12,7 @@ import {
 } from "../../lib/constants/dbPrefixes";
 import { DataPlayerSheet } from "../../lib/dataTypes";
 import { generateJoinCode } from "../../lib/joinCode";
+import { getTranslatedMessage } from "../../lib/i18n";
 
 export function request(
   context: Context<{ input: CreateGameInput }> & {
@@ -29,7 +30,10 @@ export function request(
 
   const gameDefaults = context.stash.gameDefaults;
   if (!gameDefaults) {
-    util.error("Game defaults not found in stash", "MissingGameDefaults");
+    util.error(
+      getTranslatedMessage("gameDefaults.missing", input.language),
+      "MissingGameDefaults",
+    );
   }
 
   context.stash.record = {

--- a/graphql/function/getGameDefaults/getGameDefaults.ts
+++ b/graphql/function/getGameDefaults/getGameDefaults.ts
@@ -4,6 +4,7 @@ import { DDBPrefixGameDefaults } from "../../lib/constants/dbPrefixes";
 import { FallbackLanguage } from "../../lib/constants/defaults";
 import type { GameDefaults, DynamoDBGameDefaults } from "../../lib/dataTypes";
 import type { JoinGameInput, CreateGameInput } from "../../../appsync/graphql";
+import { getTranslatedMessage } from "../../lib/i18n";
 
 export function request(
   context: Context<{ input: JoinGameInput | CreateGameInput }>,
@@ -76,7 +77,10 @@ export function response(
 
   // If we don't have a result from database, error out
   if (!gameDefaults) {
-    util.error(`Invalid game type: ${gameType}`, "InvalidGameType");
+    util.error(
+      getTranslatedMessage("game.invalidType", language, gameType),
+      "InvalidGameType",
+    );
   }
 
   const defaultNPCs = gameDefaults.defaultNPCs.map((npcItem) => ({

--- a/graphql/lib/i18n.ts
+++ b/graphql/lib/i18n.ts
@@ -21,6 +21,8 @@ const translations: TranslationsByLanguage = {
     "sheet.notFound": "Sheet not found",
     "gameRecord.notFound": "Game record not found",
     "gameDefaults.missing": "Game defaults not found in stash",
+    "game.unknownType": "Unknown type",
+    "game.invalidType": "Invalid game type",
   },
   tlh: {
     // Klingon translations - these are placeholders and would need proper translation
@@ -32,31 +34,42 @@ const translations: TranslationsByLanguage = {
     "sheet.notFound": "naQ DIch tu'lu'be'",
     "gameRecord.notFound": "nugh DIch teywI' tu'lu'be'",
     "gameDefaults.missing": "nugh DIch nugh DIch polmeH DIch tu'lu'be'",
+    "game.unknownType": "Sovbe'ghach Segh",
+    "game.invalidType": "nugh DIch lo'taHbe'",
   },
 };
 
 /**
- * Get a translated error message
+ * Get a translated error message with optional value concatenation
  * @param messageKey - The message key to translate
  * @param language - The target language (defaults to 'en' if not supported)
+ * @param value - Optional value to append after ": " (e.g. "Invalid game type: someValue")
  * @returns The translated message, falling back to English if translation not found
  */
 export function getTranslatedMessage(
   messageKey: string,
   language: string = defaultLanguage,
+  value?: string,
 ): string {
   // Try to get the requested language
-  if (translations[language]?.[messageKey]) {
-    return translations[language][messageKey];
-  }
+  let message = translations[language]?.[messageKey];
 
-  // Fall back to English
-  if (translations[defaultLanguage]?.[messageKey]) {
-    return translations[defaultLanguage][messageKey];
+  // Fall back to English if not found
+  if (!message) {
+    message = translations[defaultLanguage]?.[messageKey];
   }
 
   // Ultimate fallback - return the message key
-  return messageKey;
+  if (!message) {
+    return messageKey;
+  }
+
+  // Append value if provided (format: "message: value")
+  if (value) {
+    message = message + ": " + value;
+  }
+
+  return message;
 }
 
 /**

--- a/graphql/lib/i18n.ts
+++ b/graphql/lib/i18n.ts
@@ -59,9 +59,9 @@ export function getTranslatedMessage(
     message = translations[defaultLanguage]?.[messageKey];
   }
 
-  // Ultimate fallback - return the message key
+  // Ultimate fallback - return messageKey: value format
   if (!message) {
-    return messageKey;
+    return value ? messageKey + ": " + value : messageKey;
   }
 
   // Append value if provided (format: "message: value")


### PR DESCRIPTION
## Summary
- Fix i18n fallback logic to properly handle "messageKey: value" format when no translation is found
- Update i18n system to use simple string concatenation for values (APPSYNC_JS compatible)
- Apply i18n pattern to createGame and getGameDefaults functions with proper error message localization

## Changes
- **graphql/lib/i18n.ts**: Fix ultimate fallback to return "messageKey: value" format instead of just messageKey
- **graphql/function/createGame/createGame.ts**: Use localized "gameDefaults.missing" error message
- **graphql/function/getGameDefaults/getGameDefaults.ts**: Use localized "game.invalidType" error with value concatenation

## Test plan
- [x] Deploy with `make dev` 
- [x] Test getGameDefaults with invalid game type to verify "Invalid game type: invalidType" format
- [x] Test createGame error scenarios to verify gameDefaults.missing localization
- [x] Verify APPSYNC_JS compatibility (no for loops or complex interpolation)

🤖 Generated with [Claude Code](https://claude.ai/code)