### PR TITLE
Fix Klingon translations for game display names

### DIFF
--- a/terraform/module/wildsea/gamedefaults.tf
+++ b/terraform/module/wildsea/gamedefaults.tf
@@ -107,7 +107,7 @@ resource "aws_dynamodb_table_item" "gamedefaults_wildsea_tlh" {
       S = "wildsea"
     }
     displayName = {
-      S = "TODO$Wildsea$tlh"
+      S = "mI'lugh bIQ"
     }
     defaultCharacterName = {
       S = "motlhbe' jup"
@@ -154,7 +154,7 @@ resource "aws_dynamodb_table_item" "gamedefaults_deltagreen_tlh" {
       S = "deltaGreen"
     }
     displayName = {
-      S = "TODO$Delta Green$tlh"
+      S = "mI'lugh SuD"
     }
     defaultCharacterName = {
       S = "Sovbe'ghach DIch"


### PR DESCRIPTION
## Summary
- Replace TODO placeholders with proper Klingon translations for game display names
- Wildsea: "mI'lugh bIQ" (Wild Sea)
- Delta Green: "mI'lugh SuD" (Wild Green)

## Test plan
- [x] Deploy to dev environment with `make dev`
- [ ] Verify Klingon game display names appear correctly in UI
- [ ] Test game creation with Klingon locale

🤖 Generated with [Claude Code](https://claude.ai/code)