### PR TITLE
Implement per-character section quota system (#925)

### DIFF
--- a/appsync/graphql.ts
+++ b/appsync/graphql.ts
@@ -103,6 +103,7 @@ export type Game = {
   joinCode?: Maybe<Scalars['String']['output']>;
   playerSheets: Array<PlayerSheet>;
   remainingCharacters: Scalars['Int']['output'];
+  remainingSections: Scalars['Int']['output'];
   theme?: Maybe<Scalars['String']['output']>;
   type: Scalars['String']['output'];
   updatedAt: Scalars['AWSDateTime']['output'];
@@ -119,6 +120,7 @@ export type GameSummary = {
   gameType: Scalars['String']['output'];
   joinCode?: Maybe<Scalars['String']['output']>;
   remainingCharacters: Scalars['Int']['output'];
+  remainingSections: Scalars['Int']['output'];
   theme?: Maybe<Scalars['String']['output']>;
   type: Scalars['String']['output'];
   updatedAt: Scalars['AWSDateTime']['output'];
@@ -244,6 +246,7 @@ export type PlayerSheet = {
   createdAt: Scalars['AWSDateTime']['output'];
   fireflyUserId: Scalars['ID']['output'];
   gameId: Scalars['ID']['output'];
+  remainingSections: Scalars['Int']['output'];
   sections: Array<SheetSection>;
   type: Scalars['String']['output'];
   updatedAt: Scalars['AWSDateTime']['output'];
@@ -259,6 +262,7 @@ export type PlayerSheetSummary = {
   gameId: Scalars['ID']['output'];
   gameName: Scalars['String']['output'];
   gameType: Scalars['String']['output'];
+  remainingSections: Scalars['Int']['output'];
   type: Scalars['String']['output'];
   updatedAt: Scalars['AWSDateTime']['output'];
   userId: Scalars['ID']['output'];

--- a/appsync/schema.ts
+++ b/appsync/schema.ts
@@ -3,7 +3,7 @@
       export const getGameQuery = `
         query getGame($input: GetGameInput!) {
           getGame(input: $input) {
-            gameId gameName gameType gameDescription playerSheets { userId gameId characterName sections { userId gameId sectionId type sectionName sectionType content position createdAt updatedAt deleted } type createdAt updatedAt fireflyUserId } joinCode fireflyUserId createdAt updatedAt type deleted theme remainingCharacters
+            gameId gameName gameType gameDescription playerSheets { userId gameId characterName sections { userId gameId sectionId type sectionName sectionType content position createdAt updatedAt deleted } type createdAt updatedAt fireflyUserId remainingSections } joinCode fireflyUserId createdAt updatedAt type deleted theme remainingCharacters remainingSections
           }
         }
       `;
@@ -11,7 +11,7 @@
       export const getGamesQuery = `
         query getGames {
           getGames {
-            userId gameId gameName gameType gameDescription characterName type createdAt updatedAt deleted
+            userId gameId gameName gameType gameDescription characterName type createdAt updatedAt deleted remainingSections
           }
         }
       `;
@@ -53,7 +53,7 @@
       export const createGameMutation = `
         mutation createGame($input: CreateGameInput!) {
           createGame(input: $input) {
-            gameId gameName gameType gameDescription joinCode fireflyUserId createdAt updatedAt type deleted theme remainingCharacters
+            gameId gameName gameType gameDescription joinCode fireflyUserId createdAt updatedAt type deleted theme remainingCharacters remainingSections
           }
         }
       `;
@@ -61,7 +61,7 @@
       export const joinGameMutation = `
         mutation joinGame($input: JoinGameInput!) {
           joinGame(input: $input) {
-            userId gameId gameName gameType gameDescription characterName type createdAt updatedAt deleted
+            userId gameId gameName gameType gameDescription characterName type createdAt updatedAt deleted remainingSections
           }
         }
       `;
@@ -69,7 +69,7 @@
       export const updateGameMutation = `
         mutation updateGame($input: UpdateGameInput!) {
           updateGame(input: $input) {
-            gameId gameName gameType gameDescription joinCode fireflyUserId createdAt updatedAt type deleted theme remainingCharacters
+            gameId gameName gameType gameDescription joinCode fireflyUserId createdAt updatedAt type deleted theme remainingCharacters remainingSections
           }
         }
       `;
@@ -77,7 +77,7 @@
       export const deleteGameMutation = `
         mutation deleteGame($input: DeleteGameInput!) {
           deleteGame(input: $input) {
-            gameId gameName gameType gameDescription joinCode fireflyUserId createdAt updatedAt type deleted theme remainingCharacters
+            gameId gameName gameType gameDescription joinCode fireflyUserId createdAt updatedAt type deleted theme remainingCharacters remainingSections
           }
         }
       `;
@@ -85,7 +85,7 @@
       export const updateJoinCodeMutation = `
         mutation updateJoinCode($input: UpdateJoinCodeInput!) {
           updateJoinCode(input: $input) {
-            gameId gameName gameType gameDescription joinCode fireflyUserId createdAt updatedAt type deleted theme remainingCharacters
+            gameId gameName gameType gameDescription joinCode fireflyUserId createdAt updatedAt type deleted theme remainingCharacters remainingSections
           }
         }
       `;
@@ -117,7 +117,7 @@
       export const updatePlayerMutation = `
         mutation updatePlayer($input: UpdatePlayerInput!) {
           updatePlayer(input: $input) {
-            userId gameId gameName gameType gameDescription characterName type createdAt updatedAt deleted
+            userId gameId gameName gameType gameDescription characterName type createdAt updatedAt deleted remainingSections
           }
         }
       `;
@@ -125,7 +125,7 @@
       export const deletePlayerMutation = `
         mutation deletePlayer($input: DeletePlayerInput!) {
           deletePlayer(input: $input) {
-            userId gameId gameName gameType gameDescription characterName type createdAt updatedAt deleted
+            userId gameId gameName gameType gameDescription characterName type createdAt updatedAt deleted remainingSections
           }
         }
       `;
@@ -133,7 +133,7 @@
       export const createNPCMutation = `
         mutation createNPC($input: CreateNPCInput!) {
           createNPC(input: $input) {
-            userId gameId gameName gameType gameDescription characterName type createdAt updatedAt deleted
+            userId gameId gameName gameType gameDescription characterName type createdAt updatedAt deleted remainingSections
           }
         }
       `;
@@ -159,7 +159,7 @@
       export const updatedPlayerSubscription = `
         subscription updatedPlayer($gameId: ID!) {
           updatedPlayer(gameId: $gameId) {
-            userId gameId gameName gameType gameDescription characterName type createdAt updatedAt deleted
+            userId gameId gameName gameType gameDescription characterName type createdAt updatedAt deleted remainingSections
           }
         }
       `;
@@ -175,7 +175,7 @@
       export const updatedGameSubscription = `
         subscription updatedGame($gameId: ID!) {
           updatedGame(gameId: $gameId) {
-            gameId gameName gameType gameDescription joinCode fireflyUserId createdAt updatedAt type deleted theme remainingCharacters
+            gameId gameName gameType gameDescription joinCode fireflyUserId createdAt updatedAt type deleted theme remainingCharacters remainingSections
           }
         }
       `;

--- a/graphql/function/createGame/createGame.ts
+++ b/graphql/function/createGame/createGame.ts
@@ -55,6 +55,7 @@ export function request(
     type: TypeGame,
     theme: gameDefaults.theme,
     remainingCharacters: remainingCharacters,
+    remainingSections: gameDefaults.remainingSections,
   };
 
   const gameItem = {
@@ -88,6 +89,7 @@ export function request(
       createdAt: timestamp,
       updatedAt: timestamp,
       type: TypeFirefly,
+      remainingSections: gameDefaults.remainingSections,
     } as DataPlayerSheet) as PutItemInputAttributeMap,
   };
 
@@ -114,6 +116,7 @@ export function request(
         createdAt: timestamp,
         updatedAt: timestamp,
         type: npcConfig.type,
+        remainingSections: gameDefaults.remainingSections,
       } as DataPlayerSheet) as PutItemInputAttributeMap,
     };
 
@@ -143,5 +146,6 @@ export function response(context: Context): GameSummary | null {
     type: context.stash.record.type,
     theme: context.stash.record.theme,
     remainingCharacters: context.stash.record.remainingCharacters,
+    remainingSections: context.stash.record.remainingSections,
   };
 }

--- a/graphql/function/createNPC/createNPC.ts
+++ b/graphql/function/createNPC/createNPC.ts
@@ -23,6 +23,7 @@ export function request(context: Context<{ input: CreateNPCInput }>): unknown {
     createdAt: timestamp,
     updatedAt: timestamp,
     type: TypeNPC,
+    remainingSections: context.prev.result.remainingSections,
   } as DataPlayerSheet;
 
   const playerItem = {

--- a/graphql/function/createSection/createSection.ts
+++ b/graphql/function/createSection/createSection.ts
@@ -1,13 +1,12 @@
 import { util, Context } from "@aws-appsync/utils";
-import type {
-  DynamoDBPutItemRequest,
-  PutItemInputAttributeMap,
-} from "@aws-appsync/utils/lib/resolver-return-types";
-import { Game, CreateSectionInput } from "../../../appsync/graphql";
+import type { PutItemInputAttributeMap } from "@aws-appsync/utils/lib/resolver-return-types";
+import environment from "../../environment.json";
+import { SheetSection, CreateSectionInput } from "../../../appsync/graphql";
 import {
   DDBPrefixGame,
   DDBPrefixSection,
   DDBPrefixSectionUser,
+  DDBPrefixPlayer,
 } from "../../lib/constants/dbPrefixes";
 import { TypeSection } from "../../lib/constants/entityTypes";
 
@@ -15,37 +14,80 @@ import { TypeSection } from "../../lib/constants/entityTypes";
 
 export function request(
   context: Context<{ input: CreateSectionInput }>,
-): DynamoDBPutItemRequest {
+): unknown {
   const input = context.arguments.input;
   const sectionId = util.autoId();
   const timestamp = util.time.nowISO8601();
 
-  return {
+  // Update player sheet to decrement remainingSections
+  const playerItem = {
+    operation: "UpdateItem",
+    table: "Wildsea-" + environment.name,
+    key: util.dynamodb.toMapValues({
+      PK: DDBPrefixGame + "#" + input.gameId,
+      SK: DDBPrefixPlayer + "#" + input.userId,
+    }),
+    update: {
+      expression:
+        "SET #updatedAt = :updatedAt, #remainingSections = #remainingSections - :one",
+      expressionNames: {
+        "#updatedAt": "updatedAt",
+        "#remainingSections": "remainingSections",
+      },
+      expressionValues: {
+        ":updatedAt": { S: timestamp },
+        ":one": { N: "1" },
+      },
+    },
+    condition: {
+      expression: "#remainingSections > :zero",
+      expressionNames: {
+        "#remainingSections": "remainingSections",
+      },
+      expressionValues: {
+        ":zero": { N: "0" },
+      },
+    },
+  } as PutItemInputAttributeMap;
+
+  // Create the section
+  const sectionData = {
+    gameId: input.gameId,
+    userId: input.userId,
+    sectionId: sectionId,
+    sectionName: input.sectionName,
+    sectionType: input.sectionType,
+    GSI1PK: DDBPrefixSectionUser + "#" + input.userId,
+    content: input.content,
+    position: input.position,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    type: TypeSection,
+    playerType: context.stash.playerType,
+  };
+
+  const sectionItem = {
     operation: "PutItem",
+    table: "Wildsea-" + environment.name,
     key: util.dynamodb.toMapValues({
       PK: DDBPrefixGame + "#" + input.gameId,
       SK: DDBPrefixSection + "#" + sectionId,
     }),
-    attributeValues: util.dynamodb.toMapValues({
-      gameId: input.gameId,
-      userId: input.userId,
-      sectionId: sectionId,
-      sectionName: input.sectionName,
-      sectionType: input.sectionType,
-      GSI1PK: DDBPrefixSectionUser + "#" + input.userId,
-      content: input.content,
-      position: input.position,
-      createdAt: timestamp,
-      updatedAt: timestamp,
-      type: TypeSection,
-      playerType: context.stash.playerType,
-    }) as PutItemInputAttributeMap,
+    attributeValues: util.dynamodb.toMapValues(sectionData),
+  } as PutItemInputAttributeMap;
+
+  // Store section data for response
+  context.stash.sectionData = sectionData;
+
+  return {
+    operation: "TransactWriteItems",
+    transactItems: [playerItem, sectionItem],
   };
 }
 
-export function response(context: Context): Game | null {
+export function response(context: Context): SheetSection | null {
   if (context.error) {
     util.error(context.error.message, context.error.type, context.result);
   }
-  return context.result;
+  return context.stash.sectionData;
 }

--- a/graphql/function/deleteSection/deleteSection.ts
+++ b/graphql/function/deleteSection/deleteSection.ts
@@ -1,27 +1,60 @@
 import { util, Context, AppSyncIdentityCognito } from "@aws-appsync/utils";
-import type { DynamoDBDeleteItemRequest } from "@aws-appsync/utils/lib/resolver-return-types";
+import type { PutItemInputAttributeMap } from "@aws-appsync/utils/lib/resolver-return-types";
 import { SheetSection, DeleteSectionInput } from "../../../appsync/graphql";
 import {
   DDBPrefixGame,
   DDBPrefixSection,
+  DDBPrefixPlayer,
 } from "../../lib/constants/dbPrefixes";
 import { TypeNPC } from "../../lib/constants/entityTypes";
+import environment from "../../environment.json";
 
 export function request(
   context: Context<{ input: DeleteSectionInput }>,
-): DynamoDBDeleteItemRequest {
+): unknown {
   if (!context.identity) util.unauthorized();
   const identity = context.identity as AppSyncIdentityCognito;
   if (!identity?.sub) util.unauthorized();
 
   const input = context.arguments.input;
+  const timestamp = util.time.nowISO8601();
 
-  return {
+  // Get the section data from stash (set by getSectionData pipeline function)
+  const sectionData = context.stash.sectionData;
+  if (!sectionData) {
+    util.error("Section data not found in stash");
+  }
+
+  // Update player sheet to increment remainingSections
+  const playerItem = {
+    operation: "UpdateItem",
+    table: "Wildsea-" + environment.name,
+    key: util.dynamodb.toMapValues({
+      PK: DDBPrefixGame + "#" + input.gameId,
+      SK: DDBPrefixPlayer + "#" + sectionData.userId,
+    }),
+    update: {
+      expression:
+        "SET #updatedAt = :updatedAt, #remainingSections = #remainingSections + :one",
+      expressionNames: {
+        "#updatedAt": "updatedAt",
+        "#remainingSections": "remainingSections",
+      },
+      expressionValues: {
+        ":updatedAt": { S: timestamp },
+        ":one": { N: "1" },
+      },
+    },
+  } as PutItemInputAttributeMap;
+
+  // Delete the section
+  const sectionItem = {
+    operation: "DeleteItem",
+    table: "Wildsea-" + environment.name,
     key: util.dynamodb.toMapValues({
       PK: DDBPrefixGame + "#" + input.gameId,
       SK: DDBPrefixSection + "#" + input.sectionId,
     }),
-    operation: "DeleteItem",
     condition: {
       expression: "#userId = :userId OR #playerType = :playerType",
       expressionNames: {
@@ -33,6 +66,13 @@ export function request(
         ":playerType": TypeNPC,
       }),
     },
+  } as PutItemInputAttributeMap;
+
+  // Section data is already in stash from getSectionData pipeline function
+
+  return {
+    operation: "TransactWriteItems",
+    transactItems: [playerItem, sectionItem],
   };
 }
 
@@ -44,5 +84,6 @@ export function response(context: Context): SheetSection | null {
   }
 
   // If the deletion was successful, return a SheetSection object with the deleted flag set to true
-  return { ...context.result, deleted: true };
+  // We use the section data from stash since the transaction doesn't return the deleted item
+  return { ...context.stash.sectionData, deleted: true };
 }

--- a/graphql/function/getGame/getGame.ts
+++ b/graphql/function/getGame/getGame.ts
@@ -159,6 +159,7 @@ export function makeGameData(data: DataGame, sub: string): Game {
     type: data.type,
     theme: data.theme,
     remainingCharacters: data.remainingCharacters,
+    remainingSections: data.remainingSections,
   };
 }
 
@@ -172,6 +173,7 @@ export function makeCharacterSheetData(data: DataPlayerSheet): PlayerSheet {
     type: data.type,
     sections: [],
     fireflyUserId: data.fireflyUserId,
+    remainingSections: data.remainingSections,
   };
 }
 

--- a/graphql/function/getGameDefaults/getGameDefaults.ts
+++ b/graphql/function/getGameDefaults/getGameDefaults.ts
@@ -94,6 +94,7 @@ export function response(
     defaultNPCs: defaultNPCs,
     theme: gameDefaults.theme,
     remainingCharacters: gameDefaults.remainingCharacters,
+    remainingSections: gameDefaults.remainingSections,
   };
 
   // Store the defaults in stash for the next function to use

--- a/graphql/function/getSectionData/getSectionData.ts
+++ b/graphql/function/getSectionData/getSectionData.ts
@@ -1,0 +1,41 @@
+import { util, Context, AppSyncIdentityCognito } from "@aws-appsync/utils";
+import type { DynamoDBGetItemRequest } from "@aws-appsync/utils/lib/resolver-return-types";
+import { DeleteSectionInput } from "../../../appsync/graphql";
+import {
+  DDBPrefixGame,
+  DDBPrefixSection,
+} from "../../lib/constants/dbPrefixes";
+
+export function request(
+  context: Context<{ input: DeleteSectionInput }>,
+): DynamoDBGetItemRequest {
+  if (!context.identity) util.unauthorized();
+  const identity = context.identity as AppSyncIdentityCognito;
+  if (!identity?.sub) util.unauthorized();
+
+  const input = context.arguments.input;
+
+  return {
+    operation: "GetItem",
+    key: util.dynamodb.toMapValues({
+      PK: DDBPrefixGame + "#" + input.gameId,
+      SK: DDBPrefixSection + "#" + input.sectionId,
+    }),
+  };
+}
+
+export function response(context: Context): null {
+  if (context.error) {
+    util.error(context.error.message, context.error.type, context.result);
+  }
+
+  // Store section data in stash for the deleteSection function to use
+  if (context.result) {
+    context.stash.sectionData = context.result;
+  } else {
+    // Section not found
+    util.error("Section not found");
+  }
+
+  return null;
+}

--- a/graphql/function/joinGame/joinGame.ts
+++ b/graphql/function/joinGame/joinGame.ts
@@ -67,6 +67,7 @@ export function request(context: Context<{ input: JoinGameInput }>): unknown {
     type: TypeCharacter,
     createdAt: timestamp,
     updatedAt: timestamp,
+    remainingSections: context.prev.result.remainingSections,
   } as DataPlayerSheet;
   const playerItem = {
     operation: "PutItem",

--- a/graphql/lib/dataTypes.ts
+++ b/graphql/lib/dataTypes.ts
@@ -49,6 +49,7 @@ export interface DynamoDBGameDefaults {
   defaultNPCs: DynamoDBNPCConfig[];
   theme: string;
   remainingCharacters: number;
+  remainingSections: number;
 }
 
 // Type for game defaults from database
@@ -58,4 +59,5 @@ export interface GameDefaults {
   defaultNPCs: NPCConfig[];
   theme: string;
   remainingCharacters: number;
+  remainingSections: number;
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -135,6 +135,7 @@ type GameSummary @aws_cognito_user_pools {
   deleted: Boolean
   theme: String
   remainingCharacters: Int!
+  remainingSections: Int!
 }
 
 type Game @aws_cognito_user_pools {
@@ -151,6 +152,7 @@ type Game @aws_cognito_user_pools {
   deleted: Boolean
   theme: String
   remainingCharacters: Int!
+  remainingSections: Int!
 }
 
 input UpdatePlayerInput {
@@ -175,6 +177,7 @@ type PlayerSheetSummary @aws_cognito_user_pools @aws_iam {
   createdAt: AWSDateTime!
   updatedAt: AWSDateTime!
   deleted: Boolean
+  remainingSections: Int!
 }
 
 type PlayerSheet @aws_cognito_user_pools {
@@ -186,6 +189,7 @@ type PlayerSheet @aws_cognito_user_pools {
   createdAt: AWSDateTime!
   updatedAt: AWSDateTime!
   fireflyUserId: ID!
+  remainingSections: Int!
 }
 
 type SheetSection @aws_cognito_user_pools {

--- a/graphql/tests/checkGameAccess.test.ts
+++ b/graphql/tests/checkGameAccess.test.ts
@@ -153,6 +153,7 @@ describe("permitted", () => {
     fireflyUserId: "firefly-sub",
     players: [],
     remainingCharacters: 20,
+    remainingSections: 50,
   };
 
   it("should return false if data is null", () => {

--- a/graphql/tests/createGame.test.ts
+++ b/graphql/tests/createGame.test.ts
@@ -38,6 +38,7 @@ describe("request function", () => {
           defaultNPCs: { type: string; characterName: string }[];
           theme: string;
           remainingCharacters: number;
+          remainingSections: number;
         };
       };
     } = {
@@ -83,6 +84,7 @@ describe("request function", () => {
           ],
           theme: "wildsea",
           remainingCharacters: 20,
+          remainingSections: 50,
         },
       },
       prev: undefined,
@@ -128,6 +130,7 @@ describe("request function", () => {
             type: { S: "GAME" },
             theme: { S: "wildsea" },
             remainingCharacters: { N: "18" },
+            remainingSections: { N: "50" },
           },
         },
         {
@@ -149,6 +152,7 @@ describe("request function", () => {
             updatedAt: { S: mockTimestamp },
             type: { S: "FIREFLY" },
             characterName: { S: "Test Firefly" },
+            remainingSections: { N: "50" },
           },
         },
         {
@@ -169,6 +173,7 @@ describe("request function", () => {
             updatedAt: { S: mockTimestamp },
             type: { S: "NPC" },
             characterName: { S: "Test Ship" },
+            remainingSections: { N: "50" },
           },
         },
       ],
@@ -192,6 +197,7 @@ describe("request function", () => {
           defaultNPCs: { type: string; characterName: string }[];
           theme: string;
           remainingCharacters: number;
+          remainingSections: number;
         };
       };
     } = {
@@ -235,6 +241,7 @@ describe("request function", () => {
           ],
           theme: "wildsea",
           remainingCharacters: 20,
+          remainingSections: 50,
         },
       },
       prev: undefined,
@@ -265,6 +272,7 @@ describe("request function", () => {
           defaultNPCs: { type: string; characterName: string }[];
           theme: string;
           remainingCharacters: number;
+          remainingSections: number;
         };
       };
     } = {
@@ -308,6 +316,7 @@ describe("request function", () => {
           ],
           theme: "wildsea",
           remainingCharacters: 20,
+          remainingSections: 50,
         },
       },
       prev: undefined,

--- a/graphql/tests/getGame.test.ts
+++ b/graphql/tests/getGame.test.ts
@@ -133,6 +133,7 @@ describe("response", () => {
             joinCode: "ABC123",
             type: TypeGame,
             remainingCharacters: 20,
+            remainingSections: 50,
           } as DataGame,
           {
             userId: "user1",
@@ -142,6 +143,7 @@ describe("response", () => {
             createdAt: "2023-01-01",
             updatedAt: "2023-01-02",
             type: TypeCharacter,
+            remainingSections: 50,
           } as DataPlayerSheet,
           {
             userId: "user1",
@@ -163,6 +165,7 @@ describe("response", () => {
             createdAt: "2023-01-01",
             updatedAt: "2023-01-02",
             type: TypeFirefly,
+            remainingSections: 50,
           } as DataPlayerSheet,
         ],
       },
@@ -190,6 +193,7 @@ describe("response", () => {
           createdAt: "2023-01-01",
           updatedAt: "2023-01-02",
           type: TypeCharacter,
+          remainingSections: 50,
           sections: [
             {
               userId: "user1",
@@ -213,6 +217,7 @@ describe("response", () => {
           createdAt: "2023-01-01",
           updatedAt: "2023-01-02",
           type: TypeFirefly,
+          remainingSections: 50,
           sections: [],
         },
       ],
@@ -222,6 +227,7 @@ describe("response", () => {
       updatedAt: "2023-01-02",
       type: TypeGame,
       remainingCharacters: 20,
+      remainingSections: 50,
       theme: undefined,
     });
   });
@@ -249,6 +255,7 @@ describe("response", () => {
             joinCode: "ABC123",
             type: TypeGame,
             remainingCharacters: 20,
+            remainingSections: 50,
           } as DataGame,
           {
             userId: "user1",
@@ -258,6 +265,7 @@ describe("response", () => {
             createdAt: "2023-01-01",
             updatedAt: "2023-01-02",
             type: TypeCharacter,
+            remainingSections: 50,
           } as DataPlayerSheet,
           {
             userId: "user1",
@@ -279,6 +287,7 @@ describe("response", () => {
             createdAt: "2023-01-01",
             updatedAt: "2023-01-02",
             type: TypeFirefly,
+            remainingSections: 50,
           } as DataPlayerSheet,
         ],
       },
@@ -306,6 +315,7 @@ describe("response", () => {
           createdAt: "2023-01-01",
           updatedAt: "2023-01-02",
           type: TypeCharacter,
+          remainingSections: 50,
           sections: [
             {
               userId: "user1",
@@ -329,6 +339,7 @@ describe("response", () => {
           createdAt: "2023-01-01",
           updatedAt: "2023-01-02",
           type: TypeFirefly,
+          remainingSections: 50,
           sections: [],
         },
       ],
@@ -338,6 +349,7 @@ describe("response", () => {
       updatedAt: "2023-01-02",
       type: TypeGame,
       remainingCharacters: 20,
+      remainingSections: 50,
       theme: undefined,
     });
   });
@@ -360,6 +372,7 @@ describe("response", () => {
             createdAt: "2023-01-01",
             updatedAt: "2023-01-02",
             type: TypeCharacter,
+            remainingSections: 50,
           } as DataPlayerSheet,
         ],
       },
@@ -396,6 +409,7 @@ describe("response", () => {
             updatedAt: "2023-01-02",
             type: TypeGame,
             remainingCharacters: 20,
+            remainingSections: 50,
           } as DataGame,
           {
             type: "UNKNOWN_TYPE",
@@ -428,6 +442,7 @@ describe("makeGameData", () => {
       players: ["user3", "user2"],
       fireflyUserId: "user1",
       remainingCharacters: 20,
+      remainingSections: 50,
     };
 
     const result = makeGameData(data, "notFirefly");
@@ -444,6 +459,7 @@ describe("makeGameData", () => {
       updatedAt: "2023-01-02",
       type: TypeGame,
       remainingCharacters: 20,
+      remainingSections: 50,
       theme: undefined,
     });
   });
@@ -461,6 +477,7 @@ describe("makeGameData", () => {
       players: ["user3", "user2"],
       fireflyUserId: "user1",
       remainingCharacters: 20,
+      remainingSections: 50,
     };
 
     const result = makeGameData(data, "user1");
@@ -477,6 +494,7 @@ describe("makeGameData", () => {
       updatedAt: "2023-01-02",
       type: TypeGame,
       remainingCharacters: 20,
+      remainingSections: 50,
       theme: undefined,
     });
   });
@@ -495,6 +513,7 @@ describe("makeCharacterSheetData", () => {
       type: TypeCharacter,
       gameName: "Test Game",
       gameDescription: "A test game",
+      remainingSections: 50,
     };
 
     const result = makeCharacterSheetData(data);
@@ -508,6 +527,7 @@ describe("makeCharacterSheetData", () => {
       fireflyUserId: "XXXXX",
       type: TypeCharacter,
       sections: [],
+      remainingSections: 50,
     });
   });
 });

--- a/graphql/tests/joinGame.test.ts
+++ b/graphql/tests/joinGame.test.ts
@@ -139,6 +139,7 @@ describe("fnJoinGame request function", () => {
           gameType: "wildsea",
           gameDescription: "Test Description",
           fireflyUserId: "firefly",
+          remainingSections: 50,
         },
       },
       request: {
@@ -207,6 +208,7 @@ describe("fnJoinGame request function", () => {
             type: { S: "CHARACTER" },
             createdAt: { S: mockTimestamp },
             updatedAt: { S: mockTimestamp },
+            remainingSections: { N: "50" },
           },
         },
       ],

--- a/terraform/module/wildsea/gamedefaults.tf
+++ b/terraform/module/wildsea/gamedefaults.tf
@@ -5,6 +5,7 @@ locals {
   db_prefix_language      = "LANGUAGE"
   fallback_language       = "en"
   initial_character_quota = "20"
+  initial_section_quota   = "50"
 }
 
 # English defaults
@@ -52,6 +53,9 @@ resource "aws_dynamodb_table_item" "gamedefaults_wildsea_en" {
     remainingCharacters = {
       N = local.initial_character_quota
     }
+    remainingSections = {
+      N = local.initial_section_quota
+    }
     type = {
       S = local.db_prefix_gamedefaults
     }
@@ -90,6 +94,9 @@ resource "aws_dynamodb_table_item" "gamedefaults_deltagreen_en" {
     }
     remainingCharacters = {
       N = local.initial_character_quota
+    }
+    remainingSections = {
+      N = local.initial_section_quota
     }
     type = {
       S = local.db_prefix_gamedefaults
@@ -142,6 +149,9 @@ resource "aws_dynamodb_table_item" "gamedefaults_wildsea_tlh" {
     remainingCharacters = {
       N = local.initial_character_quota
     }
+    remainingSections = {
+      N = local.initial_section_quota
+    }
     type = {
       S = local.db_prefix_gamedefaults
     }
@@ -180,6 +190,9 @@ resource "aws_dynamodb_table_item" "gamedefaults_deltagreen_tlh" {
     }
     remainingCharacters = {
       N = local.initial_character_quota
+    }
+    remainingSections = {
+      N = local.initial_section_quota
     }
     type = {
       S = local.db_prefix_gamedefaults

--- a/terraform/module/wildsea/graphql.tf
+++ b/terraform/module/wildsea/graphql.tf
@@ -309,7 +309,7 @@ locals {
     }
     deleteSection = {
       type : "Mutation",
-      functions = ["checkGameAccess", "deleteSection"]
+      functions = ["checkGameAccess", "getSectionData", "deleteSection"]
     }
     createNPC = {
       type : "Mutation",

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -652,6 +652,12 @@ body {
   border: 1px solid var(--color-border);
   border-radius: 4px;
   display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.new-section-form {
+  display: flex;
   align-items: center;
   gap: 10px;
   flex-wrap: wrap;

--- a/ui/src/playerSheetTab.tsx
+++ b/ui/src/playerSheetTab.tsx
@@ -279,7 +279,11 @@ export const PlayerSheetTab: React.FC<{ sheet: PlayerSheet, userSubject: string,
 
       {mayEditSheet && !showNewSection && (
         <>
-          <button onClick={() => setShowNewSection(true)} className="btn-standard btn-small">
+          <button 
+            onClick={() => setShowNewSection(true)} 
+            className="btn-standard btn-small"
+            disabled={sheet.remainingSections <= 0}
+          >
             <FormattedMessage id="playerSheetTab.addSection" />
           </button>
           <button onClick={() => setShowDeleteSectionModal(true)} className="btn-danger btn-small">
@@ -290,27 +294,35 @@ export const PlayerSheetTab: React.FC<{ sheet: PlayerSheet, userSubject: string,
 
       {mayEditSheet && showNewSection && (
         <div className="new-section">
-          <input
-            id="new-section-name"
-            name="newSectionName"
-            type="text"
-            value={newSectionName}
-            onChange={(e) => setNewSectionName(e.target.value)}
-            placeholder={intl.formatMessage({ id: "sectionName" })}
-          />
-          <select value={newSectionType} onChange={(e) => setNewSectionType(e.target.value)}>
-            {sectionTypes.map(({ type, label }) => (
-              <option key={type} value={type}>
-                {intl.formatMessage({ id: label })}
-              </option>
-            ))}
-          </select>
-          <button onClick={handleCreateSection} className="btn-standard btn-small">
-            <FormattedMessage id="create" />
-          </button>
-          <button onClick={handleCancelCreateSection} className="btn-secondary btn-small">
-            <FormattedMessage id="cancel" />
-          </button>
+          <div className="new-section-quota">
+            <FormattedMessage 
+              id="sectionQuota.available" 
+              values={{ count: sheet.remainingSections }} 
+            />
+          </div>
+          <div className="new-section-form">
+            <input
+              id="new-section-name"
+              name="newSectionName"
+              type="text"
+              value={newSectionName}
+              onChange={(e) => setNewSectionName(e.target.value)}
+              placeholder={intl.formatMessage({ id: "sectionName" })}
+            />
+            <select value={newSectionType} onChange={(e) => setNewSectionType(e.target.value)}>
+              {sectionTypes.map(({ type, label }) => (
+                <option key={type} value={type}>
+                  {intl.formatMessage({ id: label })}
+                </option>
+              ))}
+            </select>
+            <button onClick={handleCreateSection} className="btn-standard btn-small">
+              <FormattedMessage id="create" />
+            </button>
+            <button onClick={handleCancelCreateSection} className="btn-secondary btn-small">
+              <FormattedMessage id="cancel" />
+            </button>
+          </div>
         </div>
       )}
 

--- a/ui/src/translations.en.ts
+++ b/ui/src/translations.en.ts
@@ -78,6 +78,7 @@ export const messagesEnglish = {
     'joinCodeModal.copyError': 'Failed to copy to clipboard',
     'joinCodeModal.refreshError': 'Failed to generate new join URL',
     'characterQuota.available': '{count, plural, =0 {This game has no character slots available.} =1 {This game has 1 character slot available.} other {This game has # character slots available.}}',
+    'sectionQuota.available': '{count, plural, =0 {This character has no section slots available.} =1 {This character has 1 section slot available.} other {This character has # section slots available.}}',
 
     'deleteGameModal.deleteGame': '🗑 Delete Game',
     'deleteGameModal.confirmation': 'Are you sure you want to delete this game?',

--- a/ui/src/translations.tlh.ts
+++ b/ui/src/translations.tlh.ts
@@ -78,6 +78,7 @@ export const messagesKlingon = {
     'joinCodeModal.copyError': 'clipboard DIch DIch',
     'joinCodeModal.refreshError': 'DIch DIch URL chenmoH DIch',
     'characterQuota.available': '{count, plural, =0 {jup DIch pagh DIch DIch.} =1 {jup DIch wa\' DIch DIch.} other {jup DIch # DIch DIch.}}',
+    'sectionQuota.available': '{count, plural, =0 {jup DIch pagh nugh DIch.} =1 {jup DIch wa\' nugh DIch.} other {jup DIch # nugh DIch.}}',
 
     'deleteGameModal.deleteGame': '🗑 DIch Dub DIch',
     'deleteGameModal.confirmation': 'DIch Dub DIch DIch\'e\' DIch\'a\'?',


### PR DESCRIPTION
## Summary
- Implements configurable section quota per player sheet (50 sections per character)
- Adds real-time UI updates when sections are created/deleted
- Implements secure quota recovery that returns quota to original section owner
- Moves section quota display inside "Add a Section" form with proper layout

## Test plan
- [x] All existing tests pass with updated mock data
- [x] Section creation decrements quota and is blocked when quota reaches 0
- [x] Section deletion increments quota for the correct player
- [x] Real-time UI updates show current quota without page reload
- [x] CSS layout displays quota text on separate line above form inputs
- [x] Authorization prevents quota exploitation via NPC manipulation

🤖 Generated with [Claude Code](https://claude.ai/code)