### PR TITLE
Fix ARIA accessibility issue in dice roll panel

### DIFF
--- a/ui/src/diceRollPanel.tsx
+++ b/ui/src/diceRollPanel.tsx
@@ -43,6 +43,9 @@ export const DiceRollPanel: React.FC<DiceRollPanelProps> = ({ gameId }) => {
   useEffect(() => {
     if (isVisible && closeButtonRef.current) {
       closeButtonRef.current.focus();
+    } else if (!isVisible && closeButtonRef.current) {
+      // Remove focus when panel is hidden to prevent aria-hidden focus conflict
+      closeButtonRef.current.blur();
     }
   }, [isVisible]);
 
@@ -151,7 +154,7 @@ export const DiceRollPanel: React.FC<DiceRollPanelProps> = ({ gameId }) => {
         className={`dice-roll-panel ${isVisible ? 'visible' : 'hidden'}`}
         role="region"
         aria-label="Dice rolls panel"
-        aria-hidden={!isVisible}
+        {...(!isVisible && { inert: '' as any })}
       >
         <div className="dice-roll-header">
           <h3 id="dice-rolls-title"><FormattedMessage id="diceRollPanel.title" /></h3>


### PR DESCRIPTION
## Summary
- Replace `aria-hidden` with `inert` attribute to prevent focus conflicts
- Add proper focus management to blur close button when panel is hidden
- Resolves browser warning about blocked aria-hidden on focused elements

## Test plan
- [ ] Open dice roll panel and verify close button receives focus
- [ ] Close dice roll panel and verify no ARIA accessibility warnings in browser console
- [ ] Test with screen reader to ensure proper accessibility behavior

Closes #920

🤖 Generated with [Claude Code](https://claude.ai/code)