### PR TITLE
Add sanity loss functionality to Delta Green SAN rolls

### DIFF
--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -1469,13 +1469,13 @@ body {
 }
 
 .sanity-loss-panel h4 {
-  margin: 0 0 8px 0;
+  margin: 0 0 8px;
   color: var(--color-danger);
   font-size: 1rem;
 }
 
 .sanity-loss-description {
-  margin: 0 0 12px 0;
+  margin: 0 0 12px;
   font-size: 0.9rem;
   color: var(--color-text-secondary);
 }

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -1459,6 +1459,69 @@ body {
   margin-left: 0;
 }
 
+/* Sanity Loss Panel */
+.sanity-loss-panel {
+  margin-top: 16px;
+  padding: 16px;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background-color: var(--color-surface-light);
+}
+
+.sanity-loss-panel h4 {
+  margin: 0 0 8px 0;
+  color: var(--color-danger);
+  font-size: 1rem;
+}
+
+.sanity-loss-description {
+  margin: 0 0 12px 0;
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+}
+
+.sanity-loss-buttons {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 12px;
+  justify-content: center;
+}
+
+.btn-sanity-loss {
+  padding: 6px 12px;
+  font-size: 0.9rem;
+  font-weight: bold;
+  border: 1px solid var(--color-danger);
+  background-color: var(--color-surface);
+  color: var(--color-danger);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s;
+  min-width: 60px;
+  text-align: center;
+}
+
+.btn-sanity-loss:hover:not(:disabled) {
+  background-color: var(--color-danger);
+  color: var(--color-surface);
+  transform: translateY(-1px);
+}
+
+.btn-sanity-loss:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.btn-sanity-loss:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.custom-actions-panel {
+  margin: 16px 0;
+}
+
 .derived-col-current {
   border-right: 1px solid var(--color-border);
 }

--- a/ui/src/components/DiceRollModal.tsx
+++ b/ui/src/components/DiceRollModal.tsx
@@ -15,6 +15,8 @@ interface DiceRollModalProps {
   initialAction: string;
   onRollComplete?: (grade: string) => void;
   onBehalfOf?: string;
+  customActionsAfterRoll?: React.ReactNode;
+  prePopulatedResult?: DiceRoll;
 }
 
 export const DiceRollModal: React.FC<DiceRollModalProps> = ({
@@ -24,7 +26,9 @@ export const DiceRollModal: React.FC<DiceRollModalProps> = ({
   skillValue,
   initialAction,
   onRollComplete,
-  onBehalfOf
+  onBehalfOf,
+  customActionsAfterRoll,
+  prePopulatedResult
 }) => {
   const intl = useIntl();
   const [action, setAction] = useState(initialAction);
@@ -38,14 +42,15 @@ export const DiceRollModal: React.FC<DiceRollModalProps> = ({
     if (isOpen) {
       setAction(initialAction);
       setTarget(skillValue);
-      setRollResult(null);
+      setRollResult(prePopulatedResult || null);
       setIsRolling(false);
       
       setTimeout(() => {
         rollButtonRef.current?.focus();
       }, 100);
     }
-  }, [isOpen, skillValue, initialAction]);
+  }, [isOpen, skillValue, initialAction, prePopulatedResult]);
+
 
 
   const targetOptions = [-40, -30, -20, -10, 0, 10, 20, 30, 40].map(modifier => {
@@ -90,6 +95,7 @@ export const DiceRollModal: React.FC<DiceRollModalProps> = ({
       onRequestClose();
     }
   };
+
 
 
   return (
@@ -182,11 +188,18 @@ export const DiceRollModal: React.FC<DiceRollModalProps> = ({
                 <FormattedMessage id="diceRollModal.result" />
               </h3>
               <DiceRollFormatter roll={rollResult} />
+              
+              {customActionsAfterRoll && (
+                <div className="custom-actions-panel">
+                  {customActionsAfterRoll}
+                </div>
+              )}
+              
               <div className="form-actions">
                 <button
                   className="btn-secondary"
                   onClick={handleClose}
-                  autoFocus
+                  autoFocus={!customActionsAfterRoll}
                 >
                   <FormattedMessage id="diceRollModal.close" />
                 </button>

--- a/ui/src/components/SanityLossActions.tsx
+++ b/ui/src/components/SanityLossActions.tsx
@@ -1,0 +1,100 @@
+import React, { useState } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { generateClient } from "aws-amplify/api";
+import { rollDiceMutation } from "../../../appsync/schema";
+import { RollDiceInput } from "../../../appsync/graphql";
+import { RollTypes } from "../../../graphql/lib/constants/rollTypes";
+
+interface SanityLossActionsProps {
+  gameId: string;
+  onBehalfOf?: string;
+  onSanityLoss: (amount: number) => void;
+  onCloseAndShowNewRoll?: (rollResult: any) => void;
+}
+
+interface SanityLossOption {
+  dice: string;
+  size: number;
+  label: string;
+}
+
+const sanityLossOptions: SanityLossOption[] = [
+  { dice: '1d4', size: 4, label: '1d4' },
+  { dice: '1d6', size: 6, label: '1d6' },
+  { dice: '1d8', size: 8, label: '1d8' },
+  { dice: '1d10', size: 10, label: '1d10' },
+  { dice: '1d20', size: 20, label: '1d20' },
+];
+
+export const SanityLossActions: React.FC<SanityLossActionsProps> = ({
+  gameId,
+  onBehalfOf,
+  onSanityLoss,
+  onCloseAndShowNewRoll
+}) => {
+  const intl = useIntl();
+  const [isRolling, setIsRolling] = useState(false);
+
+  const handleSanityLossRoll = async (option: SanityLossOption) => {
+    setIsRolling(true);
+    try {
+      const client = generateClient();
+      const input: RollDiceInput = {
+        gameId,
+        dice: [{ type: option.dice, size: option.size }],
+        rollType: RollTypes.SUM,
+        target: 0,
+        action: intl.formatMessage({ id: 'sanityLoss.action' }),
+        onBehalfOf: onBehalfOf || undefined,
+      };
+      
+      const result = await client.graphql({
+        query: rollDiceMutation,
+        variables: { input },
+      });
+
+      if ('data' in result && result.data?.rollDice) {
+        const diceRollResult = result.data.rollDice;
+        const totalRoll = diceRollResult.value || 0;
+        
+        // Apply the sanity loss immediately
+        onSanityLoss(totalRoll);
+        
+        // Close current modal and show new roll if callback provided
+        if (onCloseAndShowNewRoll) {
+          onCloseAndShowNewRoll(diceRollResult);
+        }
+      }
+    } catch (error) {
+      console.error('Error rolling for sanity loss:', error);
+      alert(intl.formatMessage({ id: 'sanityLoss.rollError' }));
+    } finally {
+      setIsRolling(false);
+    }
+  };
+
+  return (
+    <div className="sanity-loss-panel">
+      <h4>
+        <FormattedMessage id="sanityLoss.title" />
+      </h4>
+      <p className="sanity-loss-description">
+        <FormattedMessage id="sanityLoss.description" />
+      </p>
+
+      <div className="sanity-loss-buttons">
+        {sanityLossOptions.map((option) => (
+          <button
+            key={option.dice}
+            className="btn-sanity-loss"
+            onClick={() => handleSanityLossRoll(option)}
+            disabled={isRolling}
+            title={intl.formatMessage({ id: 'sanityLoss.rollTitle' }, { dice: option.label })}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/ui/src/translations.en.ts
+++ b/ui/src/translations.en.ts
@@ -251,6 +251,13 @@ export const messagesEnglish = {
     'diceRollModal.rollHelp': 'Roll a d100 against the target number',
     'diceRollModal.result': 'Roll Result',
 
+    // Sanity loss translations
+    'sanityLoss.title': 'Sanity Loss',
+    'sanityLoss.description': 'Roll for sanity loss and apply the result.',
+    'sanityLoss.action': 'Sanity loss',
+    'sanityLoss.rollTitle': 'Roll {dice} for sanity loss',
+    'sanityLoss.rollError': 'Error rolling for sanity loss. Please try again.',
+
     // Auto-populate translations
     'autoPopulate.title': 'Auto-Populate Character',
     'autoPopulate.description': 'Choose a pre-made character template to quickly set up your character sheet.',

--- a/ui/src/translations.tlh.ts
+++ b/ui/src/translations.tlh.ts
@@ -251,6 +251,13 @@ export const messagesKlingon = {
     'diceRollModal.rollHelp': 'd100 DIch DIch mI\' DIch DIch',
     'diceRollModal.result': 'DIch DIch DIch',
 
+    // valwI' DIch mugh - Sanity loss translations
+    'sanityLoss.title': 'valwI\' DIch mugh',
+    'sanityLoss.description': 'valwI\' DIch mugh DIch chenmoH \'e\' DIch.',
+    'sanityLoss.action': 'valwI\' DIch mugh',
+    'sanityLoss.rollTitle': '{dice} DIch valwI\' DIch mugh',
+    'sanityLoss.rollError': 'valwI\' DIch mugh DIch. DIch DIch naDev.',
+
     // Auto-populate translations
     'autoPopulate.title': 'DIch nugh nugh DIch',
     'autoPopulate.description': 'DIch nugh DIch nugh DIch wuq DIch nugh DIch nugh DIch chenmoH.',


### PR DESCRIPTION
## Summary
- Add sanity loss button panel that appears after SAN roll results
- Create SanityLossActions component with dice buttons (1d4, 1d6, 1d8, 1d10, 1d20)
- Roll sanity loss dice and automatically subtract result from current SAN value  
- Display sanity loss roll result in clean dice modal without additional buttons
- Support custom actions in DiceRollModal via customActionsAfterRoll prop
- Support pre-populated dice results for displaying sanity loss rolls
- Style sanity loss buttons with centered layout and consistent 60px width

## Technical Changes
- Extended DiceRollModal with customActionsAfterRoll and prePopulatedResult props
- Created SanityLossActions component for rolling and applying sanity loss
- Added ref-based system to pass update functions from renderItems to modal callbacks
- Fixed dice result extraction (use .value for SUM rolls instead of .total)
- Added English and Klingon translations for sanity loss interface
- Added comprehensive CSS styling for sanity loss panel and buttons

## Test plan
- [x] Navigate to Delta Green character sheet with SAN > 0
- [x] Click dice button next to SAN to roll d100 vs current SAN
- [x] After roll, verify sanity loss buttons (1d4, 1d6, 1d8, 1d10, 1d20) appear
- [x] Click any sanity loss button to roll dice
- [x] Verify sanity loss roll displays in new clean modal (no extra buttons)
- [x] Verify current SAN decreases by rolled amount
- [x] Test button centering and consistent width on both desktop and mobile
- [x] Verify dice rolls appear in dice panel for all players to see

🤖 Generated with [Claude Code](https://claude.ai/code)