### PR TITLE
Update Basic Agent template: Weapons section uses Delta Green Weapons section (fixes #1053)

### DIFF
--- a/terraform/module/wildsea/templates.en.tf
+++ b/terraform/module/wildsea/templates.en.tf
@@ -397,7 +397,7 @@ resource "aws_dynamodb_table_item" "template_deltagreen_basic_en" {
         },
         {
           sectionName = "Weapons"
-          sectionType = "RICHTEXT"
+          sectionType = "DELTAGREENWEAPONS"
           content = jsonencode({
             items = [
               {

--- a/terraform/module/wildsea/templates.tlh.tf
+++ b/terraform/module/wildsea/templates.tlh.tf
@@ -397,7 +397,7 @@ resource "aws_dynamodb_table_item" "template_deltagreen_basic_tlh" {
         },
         {
           sectionName = "nuH"
-          sectionType = "RICHTEXT"
+          sectionType = "DELTAGREENWEAPONS"
           content = jsonencode({
             items = [
               {


### PR DESCRIPTION
This PR updates the Basic Agent template in both English and Klingon to use the new Delta Green Weapons section type instead of a rich text box for the Weapons section.

- Updates sectionType for Weapons to DELTAGREENWEAPONS in both templates.
- Closes #1053.

Please review and merge if all looks good.