### PR TITLE
feat(ui): add i18n download option for character sheet with translations and permission logic

### DIFF
--- a/terraform/module/wildsea/cognito.tf
+++ b/terraform/module/wildsea/cognito.tf
@@ -38,8 +38,8 @@ resource "aws_cognito_user_pool_client" "cognito" {
   generate_secret                      = false
   explicit_auth_flows                  = ["ALLOW_REFRESH_TOKEN_AUTH", "ALLOW_USER_PASSWORD_AUTH", "ALLOW_USER_SRP_AUTH"]
   allowed_oauth_flows_user_pool_client = true
-  callback_urls                        = ["http://localhost:5173/", "https://${local.cdn_domain_name}/"]
-  logout_urls                          = ["http://localhost:5173/", "https://${local.cdn_domain_name}/"]
+  callback_urls                        = ["http://localhost:5173/", "http://localhost:5174/", "https://${local.cdn_domain_name}/"]
+  logout_urls                          = ["http://localhost:5173/", "http://localhost:5174/", "https://${local.cdn_domain_name}/"]
   allowed_oauth_flows                  = ["code"]
   allowed_oauth_scopes                 = ["openid", "aws.cognito.signin.user.admin"]
   supported_identity_providers         = local.providers

--- a/ui/src/frame.tsx
+++ b/ui/src/frame.tsx
@@ -5,6 +5,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import Tippy from '@tippyjs/react';
 import ReactMarkdown from 'react-markdown';
 import { supportedLanguages, type SupportedLanguage } from './translations';
+import { PlayerSheet } from '../../appsync/graphql';
 
 function handleSignInClick() {
     signOut(); // sometimes Cognito gets confused; and things you are both logged in, but can't retrieve your email address
@@ -24,10 +25,12 @@ interface TopBarProps {
   onShareGame?: () => void;
   currentLanguage?: SupportedLanguage;
   onLanguageChange?: (language: SupportedLanguage) => void;
+  activeSheet?: PlayerSheet | null;
+  mayEditActiveSheet?: boolean;
 }
 
 // TopBar component
-export const TopBar: React.FC<TopBarProps> = ({ title, userEmail, gameDescription, isGM, onEditGame, onShareGame, currentLanguage = 'en', onLanguageChange }) => {
+export const TopBar: React.FC<TopBarProps> = ({ title, userEmail, gameDescription, isGM, onEditGame, onShareGame, currentLanguage = 'en', onLanguageChange, activeSheet, mayEditActiveSheet }) => {
   const [showDropdown, setShowDropdown] = useState(false);
   const intl = useIntl();
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -127,6 +130,28 @@ export const TopBar: React.FC<TopBarProps> = ({ title, userEmail, gameDescriptio
                   </div>
                   <div className="dropdown-separator" />
                 </>
+              )}
+              {activeSheet && (
+                <button
+                  onClick={() => {
+                    if (!mayEditActiveSheet) return;
+                    const dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(activeSheet, null, 2));
+                    const defaultFilename = intl.formatMessage({ id: 'playerSheetTab.download.filename' });
+                    const filename = `${activeSheet.characterName || defaultFilename}.json`;
+                    const dlAnchor = document.createElement('a');
+                    dlAnchor.setAttribute("href", dataStr);
+                    dlAnchor.setAttribute("download", filename);
+                    document.body.appendChild(dlAnchor);
+                    dlAnchor.click();
+                    document.body.removeChild(dlAnchor);
+                  }}
+                  className="btn-standard btn-small"
+                  style={{ width: '100%', marginBottom: 4, opacity: mayEditActiveSheet ? 1 : 0.5, cursor: mayEditActiveSheet ? 'pointer' : 'not-allowed' }}
+                  disabled={!mayEditActiveSheet}
+                  title={mayEditActiveSheet ? '' : intl.formatMessage({ id: 'playerSheetTab.download.noPermission' })}
+                >
+                  <FormattedMessage id="playerSheetTab.download.button" />
+                </button>
               )}
               <button onClick={() => { handleSignOutClick(); }} className="btn-standard btn-small">
                 <FormattedMessage id="logout" />

--- a/ui/src/game.tsx
+++ b/ui/src/game.tsx
@@ -407,6 +407,15 @@ const GameContent: React.FC<{
     return <div><FormattedMessage id="loadingGameData" /></div>;
   }
 
+  // Find the currently active sheet object
+  const activeSheetObj = activeSheet ? game.playerSheets.find(s => s.userId === activeSheet) : null;
+  // Determine if the user can edit the active sheet
+  let mayEditActiveSheet = false;
+  if (activeSheetObj) {
+    if (userSubject === activeSheetObj.userId) mayEditActiveSheet = true;
+    if (activeSheetObj.type === 'NPC') mayEditActiveSheet = true;
+    if (userSubject === game.gmUserId) mayEditActiveSheet = true;
+  }
   return (
     <div className="game-container">
       <TopBar
@@ -418,6 +427,8 @@ const GameContent: React.FC<{
         onShareGame={() => setShowJoinCodeModal(true)}
         currentLanguage={currentLanguage}
         onLanguageChange={onLanguageChange}
+        activeSheet={activeSheetObj}
+        mayEditActiveSheet={mayEditActiveSheet}
       />
       <div className="tab-bar" role="tablist" aria-label={intl.formatMessage({ id: 'game.characterTabs' })}>
         {game.playerSheets

--- a/ui/src/translations.en.ts
+++ b/ui/src/translations.en.ts
@@ -1,5 +1,8 @@
 // English translations for Wildsea
 export const messagesEnglish = {
+    'playerSheetTab.download.button': 'Download as JSON',
+    'playerSheetTab.download.filename': 'character-sheet',
+    'playerSheetTab.download.noPermission': 'You do not have permission to download this sheet',
     'wildsea': 'Wildsea',
     'pleaseLogin': 'Please Log In',
     'unableToJoin': 'Unable to join game',

--- a/ui/src/translations.tlh.ts
+++ b/ui/src/translations.tlh.ts
@@ -333,4 +333,8 @@ export const messagesKlingon = {
     'language.autoDetect': 'Hol DIch tu\'',
     'language.english': 'DIch Hol',
     'language.klingon': 'tlhIngan Hol',
+
+    'playerSheetTab.download.button': 'nagh beQ yIchev',
+    'playerSheetTab.download.filename': 'nagh-beQ',
+    'playerSheetTab.download.noPermission': 'nagh beQ yIchevlaHbe\' SoH',
 };

--- a/ui/ui.mk
+++ b/ui/ui.mk
@@ -1,3 +1,5 @@
+UI_PORT ?= 5173
+
 UI_JQ_FILTER := { \
 	identity_pool: .cognito_identity_pool_id.value, \
 	user_pool: .cognito_user_pool_id.value, \
@@ -18,7 +20,7 @@ ui/config/config-%.json: ui/config/output-%.json
 .PHONY: ui-local
 ui-local: ui/config/config-dev.json appsync/schema.ts appsync/graphql.ts terraform/environment/wildsea-dev/.apply ui/node_modules
 	cp $< ui/public/config.json
-	docker run --rm -it --user $$(id -u):$$(id -g) -v $(PWD):/app -w /app/ui -p 5173:5173 node:20 npm run dev
+	docker run --rm -it --user $$(id -u):$$(id -g) -v $(PWD):/app -w /app/ui -p $(UI_PORT):5173 node:20 npm run dev
 
 ui/node_modules: ui/package.json
 	if [ -z "$(IN_PIPELINE)" ] ; then \


### PR DESCRIPTION
### Summary

- Adds a fully internationalized "Download as JSON" option to the top-level user menu in the character sheet UI.
- The download button is only enabled if the user has edit rights (owner, GM, or NPC sheet).
- All user-facing text (button, tooltip, filename) is i18n-ready for both English and Klingon.
- Fixes #160.