### PR TITLE
feat(delta-green): implement ammo decrement for weapon skill rolls (fixes #1059)

### DIFF
--- a/ui/src/translations.en.ts
+++ b/ui/src/translations.en.ts
@@ -237,11 +237,13 @@ export const messagesEnglish = {
     'deltaGreenWeapons.invalidLethality': 'Invalid lethality format (use percentage like 15%)',
     'deltaGreenWeapons.lethalityFailure': '{weapon} lethality failed: {damage} damage',
     'deltaGreenWeapons.addPresetWeapon': 'Add Preset Weapon',
+    'deltaGreenWeapons.selectWeapon': 'Select weapon',
     'deltaGreenWeapons.chooseWeapon': 'Choose a weapon...',
     'deltaGreenWeapons.addWeapon': 'Add',
     'deltaGreenWeapons.presetAdded': '{weapon} added to weapons list',
     'deltaGreenWeapons.presetAddError': 'Failed to add preset weapon',
     'deltaGreenWeapons.presetLoadError': 'Failed to load preset weapons',
+    'deltaGreenWeapons.noAmmo': 'Cannot fire {weapon} - no ammo remaining',
 
     'deltaGreenStats.rollDice': 'Roll dice for {statName}',
     'deltaGreenStats.actionWith': 'with {statName}',

--- a/ui/src/translations.tlh.ts
+++ b/ui/src/translations.tlh.ts
@@ -242,11 +242,13 @@ export const messagesKlingon = {
     'deltaGreenWeapons.invalidLethality': 'Hegh DIch mI\' DIch (15% DIch lo\')',
     'deltaGreenWeapons.lethalityFailure': '{weapon} Hegh DIch DIch: {damage} DIch',
     'deltaGreenWeapons.addPresetWeapon': 'motlhbe\' nuH chel',
+    'deltaGreenWeapons.selectWeapon': 'nuH wuq',
     'deltaGreenWeapons.chooseWeapon': 'nuH wuq...',
     'deltaGreenWeapons.addWeapon': 'chel',
     'deltaGreenWeapons.presetAdded': '{weapon} nuH DIch naQ DIch',
     'deltaGreenWeapons.presetAddError': 'motlhbe\' nuH chel DIch',
     'deltaGreenWeapons.presetLoadError': 'motlhbe\' nuH DIch DIch',
+    'deltaGreenWeapons.noAmmo': '{weapon} baH DIlo\' - jup pagh',
 
     'dice.icon': '🎲',
 


### PR DESCRIPTION
## Summary
- Implement ammo decrement when firing Delta Green weapons
- Disable weapon skill rolls when ammo count is 0
- Add missing translation key for weapon selection

## Test plan
- [x] UI tests pass
- [x] No TypeScript compilation errors
- [x] Translation keys complete
- [x] Weapon skill rolls decrement ammo correctly
- [x] Roll buttons disabled when ammo is 0
- [x] N/A and non-numeric ammo values still allow rolls

🤖 Generated with [Claude Code](https://claude.ai/code)