### PR TITLE
fix(delta-green): show/hide empty bonds now includes value=0 entries (fixes #1070)

### DIFF
--- a/ui/src/sectionDeltaGreenBonds.tsx
+++ b/ui/src/sectionDeltaGreenBonds.tsx
@@ -58,7 +58,7 @@ export const SectionDeltaGreenBonds: React.FC<SectionDefinition> = (props) => {
     updateSection: (updatedSection: Partial<SheetSection>) => Promise<void>,
     _isEditing: boolean,
   ) => {
-    const filteredItems = content.items.filter(item => content.showEmpty || item.name !== '');
+    const filteredItems = content.items.filter(item => content.showEmpty || (item.name !== '' && item.value > 0));
 
     return (
       <div className="bonds-container">


### PR DESCRIPTION
## Summary
- Fixed the Delta Green Bonds section show/hide empty logic to properly handle bonds with value=0
- When "Show Empty" is disabled, bonds with value=0 are now hidden along with bonds that have empty names
- This ensures the show/hide empty toggle works correctly for all "empty" bond entries

## Test plan
- [x] UI tests pass
- [x] Manual testing of show/hide empty toggle with bonds at value=0
- [x] Verified existing functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)