### PR TITLE
fix: add missing pipeline_number variable to terraform plan workflow

### DIFF
--- a/.github/workflows/environment-main-plan.yaml
+++ b/.github/workflows/environment-main-plan.yaml
@@ -67,6 +67,7 @@ jobs:
           domain_name="${{ vars.DOMAIN_NAME }}"
           google_client_id="${{ secrets.GOOGLE_CLIENT_ID }}"
           google_client_secret="${{ secrets.GOOGLE_CLIENT_SECRET }}"
+          pipeline_number="${{ github.run_number }}"
         backend_config:
           bucket=${{ vars.STATE_BUCKET }}
           key=${{ vars.ENVIRONMENT }}/terraform.tfstate


### PR DESCRIPTION
## Summary
- Fixed production deployment failures by adding missing `pipeline_number` variable to terraform plan workflow
- The plan workflow was missing this variable while the apply workflow included it, causing plan/apply mismatches
- Both workflows now use consistent variables ensuring successful deployments

## Test plan
- [x] Verify plan workflow includes pipeline_number variable
- [ ] Test that PR plan succeeds without errors
- [ ] Verify production deployment succeeds after merge

🤖 Generated with [Claude Code](https://claude.ai/code)