### PR TITLE
fix: use terraform output -json for consistent RUM config format

### DIFF
--- a/.github/workflows/environment-main-deploy.yaml
+++ b/.github/workflows/environment-main-deploy.yaml
@@ -90,7 +90,8 @@ jobs:
 
     - name: write UI config file
       run: |
-        echo '${{ toJSON(steps.terraform.outputs) }}' | jq 'with_entries(.value = {value: .value})' > ui/config/output-${{ vars.ENVIRONMENT }}.json
+        cd terraform/environment/wildsea
+        terraform output -json > ../../../ui/config/output-${{ vars.ENVIRONMENT }}.json
 
     - name: Push UI
       run: |


### PR DESCRIPTION
## Summary
- Fix RUM config being a JSON string in prod vs actual JSON in dev
- Replace jq transformation with direct terraform output to match dev environment
- Both environments now use `terraform output -json` consistently

## Problem
In production, the RUM config in config.json was being double-serialized:
```json
{
  "rum_config": {
    "value": "{\"applicationId\":\"...\",\"applicationVersion\":\"...\"}"
  }
}
```

In dev, it was correctly formatted as actual JSON:
```json
{
  "rum_config": {
    "value": {
      "applicationId": "...",
      "applicationVersion": "..."
    }
  }
}
```

## Solution
Changed the production workflow to use `terraform output -json` directly instead of the `jq` transformation that was causing double serialization.

## Test plan
- [ ] Verify production config.json has rum_config as actual JSON object
- [ ] Confirm dev and prod config formats are now identical

🤖 Generated with [Claude Code](https://claude.ai/code)