### PR TITLE
Add static SAN loss options to SAN roll interface

### DIFF
--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -1510,6 +1510,17 @@ body {
   color: var(--color-text-secondary);
 }
 
+.sanity-loss-static-buttons {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 12px;
+  justify-content: center;
+}
+.sanity-loss-static-buttons .btn-sanity-loss {
+  min-width: 40px;
+  padding: 6px 8px;
+}
 .sanity-loss-buttons {
   display: flex;
   gap: 8px;

--- a/ui/public/style.css
+++ b/ui/public/style.css
@@ -1517,6 +1517,7 @@ body {
   margin-top: 12px;
   justify-content: center;
 }
+
 .sanity-loss-static-buttons .btn-sanity-loss {
   min-width: 40px;
   padding: 6px 8px;

--- a/ui/src/components/SanityLossActions.test.tsx
+++ b/ui/src/components/SanityLossActions.test.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { messagesEnglish } from '../translations.en';
+import { SanityLossActions } from './SanityLossActions';
+
+// Mock AWS Amplify
+jest.mock('aws-amplify/api', () => ({
+  generateClient: () => ({
+    graphql: jest.fn(() => Promise.resolve({
+      data: {
+        rollDice: {
+          value: 5,
+          messageType: 'deltaGreen'
+        }
+      }
+    }))
+  })
+}));
+
+// Mock constants
+jest.mock('../../../graphql/lib/constants/rollTypes', () => ({
+  RollTypes: {
+    SUM: 'SUM'
+  }
+}));
+
+jest.mock('../../../appsync/schema', () => ({
+  rollDiceMutation: 'mockRollDiceMutation'
+}));
+
+const mockOnSanityLoss = jest.fn();
+const mockOnCloseAndShowNewRoll = jest.fn();
+
+const renderWithIntl = (component: React.ReactElement) => {
+  return render(
+    <IntlProvider locale="en" messages={messagesEnglish}>
+      {component}
+    </IntlProvider>
+  );
+};
+
+describe('SanityLossActions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders static sanity loss buttons (1-6)', () => {
+    renderWithIntl(
+      <SanityLossActions
+        gameId="test-game"
+        onSanityLoss={mockOnSanityLoss}
+        onCloseAndShowNewRoll={mockOnCloseAndShowNewRoll}
+      />
+    );
+
+    // Check that static buttons are rendered
+    for (let i = 1; i <= 6; i++) {
+      const button = screen.getByRole('button', { name: i.toString() });
+      expect(button).toBeInTheDocument();
+      expect(button).toHaveAttribute('title', `Lose ${i} sanity points`);
+    }
+  });
+
+  it('renders dice roll buttons', () => {
+    renderWithIntl(
+      <SanityLossActions
+        gameId="test-game"
+        onSanityLoss={mockOnSanityLoss}
+        onCloseAndShowNewRoll={mockOnCloseAndShowNewRoll}
+      />
+    );
+
+    // Check that dice buttons are rendered
+    const diceOptions = ['1d4', '1d6', '1d8', '1d10', '1d20'];
+    diceOptions.forEach(dice => {
+      const button = screen.getByRole('button', { name: dice });
+      expect(button).toBeInTheDocument();
+      expect(button).toHaveAttribute('title', `Roll ${dice} for sanity loss`);
+    });
+  });
+
+  it('calls onSanityLoss when static button is clicked', () => {
+    renderWithIntl(
+      <SanityLossActions
+        gameId="test-game"
+        onSanityLoss={mockOnSanityLoss}
+        onCloseAndShowNewRoll={mockOnCloseAndShowNewRoll}
+      />
+    );
+
+    const button3 = screen.getByRole('button', { name: '3' });
+    fireEvent.click(button3);
+
+    expect(mockOnSanityLoss).toHaveBeenCalledWith(3);
+    expect(mockOnCloseAndShowNewRoll).toHaveBeenCalledWith(null);
+  });
+
+  it('static buttons are above dice buttons in DOM order', () => {
+    const { container } = renderWithIntl(
+      <SanityLossActions
+        gameId="test-game"
+        onSanityLoss={mockOnSanityLoss}
+        onCloseAndShowNewRoll={mockOnCloseAndShowNewRoll}
+      />
+    );
+
+    const staticButtonsContainer = container.querySelector('.sanity-loss-static-buttons');
+    const diceButtonsContainer = container.querySelector('.sanity-loss-buttons');
+
+    expect(staticButtonsContainer).toBeInTheDocument();
+    expect(diceButtonsContainer).toBeInTheDocument();
+
+    // Check DOM order - static buttons should come before dice buttons
+    const allContainers = container.querySelectorAll('.sanity-loss-static-buttons, .sanity-loss-buttons');
+    expect(allContainers[0]).toBe(staticButtonsContainer);
+    expect(allContainers[1]).toBe(diceButtonsContainer);
+  });
+});

--- a/ui/src/components/SanityLossActions.test.tsx
+++ b/ui/src/components/SanityLossActions.test.tsx
@@ -73,11 +73,11 @@ describe('SanityLossActions', () => {
 
     // Check that dice buttons are rendered
     const diceOptions = ['1d4', '1d6', '1d8', '1d10', '1d20'];
-    diceOptions.forEach(dice => {
+    for (const dice of diceOptions) {
       const button = screen.getByRole('button', { name: dice });
       expect(button).toBeInTheDocument();
       expect(button).toHaveAttribute('title', `Roll ${dice} for sanity loss`);
-    });
+    }
   });
 
   it('calls onSanityLoss when static button is clicked', () => {

--- a/ui/src/components/SanityLossActions.tsx
+++ b/ui/src/components/SanityLossActions.tsx
@@ -18,6 +18,8 @@ interface SanityLossOption {
   label: string;
 }
 
+const staticSanityLossOptions = [1, 2, 3, 4, 5, 6];
+
 const sanityLossOptions: SanityLossOption[] = [
   { dice: '1d4', size: 4, label: '1d4' },
   { dice: '1d6', size: 6, label: '1d6' },
@@ -35,6 +37,16 @@ export const SanityLossActions: React.FC<SanityLossActionsProps> = ({
   const intl = useIntl();
   const [isRolling, setIsRolling] = useState(false);
 
+  const handleStaticSanityLoss = (amount: number) => {
+    // Apply the sanity loss immediately
+    onSanityLoss(amount);
+
+    // Close current modal if callback provided (no roll result for static loss)
+    if (onCloseAndShowNewRoll) {
+      onCloseAndShowNewRoll(null);
+    }
+  };
+
   const handleSanityLossRoll = async (option: SanityLossOption) => {
     setIsRolling(true);
     try {
@@ -48,7 +60,7 @@ export const SanityLossActions: React.FC<SanityLossActionsProps> = ({
         onBehalfOf: onBehalfOf || undefined,
         messageType: 'deltaGreen',
       };
-      
+
       const result = await client.graphql({
         query: rollDiceMutation,
         variables: { input },
@@ -57,10 +69,10 @@ export const SanityLossActions: React.FC<SanityLossActionsProps> = ({
       if ('data' in result && result.data?.rollDice) {
         const diceRollResult = result.data.rollDice;
         const totalRoll = diceRollResult.value || 0;
-        
+
         // Apply the sanity loss immediately
         onSanityLoss(totalRoll);
-        
+
         // Close current modal and show new roll if callback provided
         if (onCloseAndShowNewRoll) {
           onCloseAndShowNewRoll(diceRollResult);
@@ -82,6 +94,20 @@ export const SanityLossActions: React.FC<SanityLossActionsProps> = ({
       <p className="sanity-loss-description">
         <FormattedMessage id="sanityLoss.description" />
       </p>
+
+      <div className="sanity-loss-static-buttons">
+        {staticSanityLossOptions.map((amount) => (
+          <button
+            key={amount}
+            className="btn-sanity-loss"
+            onClick={() => handleStaticSanityLoss(amount)}
+            disabled={isRolling}
+            title={intl.formatMessage({ id: 'sanityLoss.staticTitle' }, { amount })}
+          >
+            {amount}
+          </button>
+        ))}
+      </div>
 
       <div className="sanity-loss-buttons">
         {sanityLossOptions.map((option) => (

--- a/ui/src/translations.en.ts
+++ b/ui/src/translations.en.ts
@@ -310,6 +310,7 @@ export const messagesEnglish = {
     'sanityLoss.description': 'Roll for sanity loss and apply the result.',
     'sanityLoss.action': 'Sanity loss',
     'sanityLoss.rollTitle': 'Roll {dice} for sanity loss',
+    'sanityLoss.staticTitle': 'Lose {amount} sanity points',
     'sanityLoss.rollError': 'Error rolling for sanity loss. Please try again.',
 
     // Auto-populate translations

--- a/ui/src/translations.tlh.ts
+++ b/ui/src/translations.tlh.ts
@@ -309,6 +309,7 @@ export const messagesKlingon = {
     'sanityLoss.description': 'valwI\' DIch mugh DIch chenmoH \'e\' DIch.',
     'sanityLoss.action': 'valwI\' DIch mugh',
     'sanityLoss.rollTitle': '{dice} DIch valwI\' DIch mugh',
+    'sanityLoss.staticTitle': 'valwI\' {amount} DIch mugh',
     'sanityLoss.rollError': 'valwI\' DIch mugh DIch. DIch DIch naDev.',
 
     // Auto-populate translations


### PR DESCRIPTION
## Summary
Implements static sanity loss options (1-6 points) for the SAN roll interface as requested in issue #1097. The new buttons are displayed above the existing dice-based options with improved styling.

## Changes Made
- **SanityLossActions Component**: Added static loss buttons (1-6 points) above existing dice options
- **UI Styling**: Static buttons are narrower (40px vs 60px) with increased spacing (12px vs 8px gap)
- **Translations**: Added support for static loss tooltips in both English and Klingon
- **Tests**: Comprehensive test coverage for new functionality including DOM ordering and button behavior
- **Backward Compatibility**: All existing dice roll functionality remains unchanged

## Technical Details
- Static buttons use dedicated `sanity-loss-static-buttons` CSS class for custom styling
- New `handleStaticSanityLoss` function handles direct point deduction without dice rolls
- Added `sanityLoss.staticTitle` translation key for tooltip text
- Tests verify proper button rendering, functionality, and DOM structure

## Test Coverage
- ✅ Static buttons (1-6) render correctly with proper tooltips
- ✅ Button clicks trigger correct sanity loss amounts
- ✅ DOM ordering ensures static buttons appear above dice buttons
- ✅ All existing dice button functionality preserved
- ✅ UI tests pass (15/15 including new SanityLossActions tests)
- ✅ GraphQL ESLint shows no errors
- ✅ TypeScript compilation successful

## Visual Changes
The implementation matches the requested design:
- Static buttons (1-6) are displayed in the first row
- Dice buttons (1d4, 1d6, 1d8, 1d10, 1d20) remain in the second row
- Improved spacing and narrower static buttons for better UX

Closes #1097

🤖 Generated with [Claude Code](https://claude.ai/code)