### PR TITLE
Fix Wildsea Basic Character template data issues

### DIFF
--- a/terraform/module/wildsea/templates.en.tf
+++ b/terraform/module/wildsea/templates.en.tf
@@ -67,25 +67,25 @@ resource "aws_dynamodb_table_item" "template_wildsea_basic_en" {
                 id          = "iron"
                 name        = "Iron"
                 description = ""
-                current     = 2
-                maximum     = 5
+                length      = 5
+                ticked      = 2
               },
               {
                 id          = "teeth"
                 name        = "Teeth"
                 description = ""
-                current     = 2
-                maximum     = 5
+                length      = 5
+                ticked      = 2
               },
               {
                 id          = "veils"
                 name        = "Veils"
                 description = ""
-                current     = 2
-                maximum     = 5
+                length      = 5
+                ticked      = 2
               }
             ]
-            showEmpty = false
+            showEmpty = true
           })
           position = 1
         },
@@ -98,46 +98,46 @@ resource "aws_dynamodb_table_item" "template_wildsea_basic_en" {
                 id          = "break"
                 name        = "Break"
                 description = ""
-                current     = 0
-                maximum     = 3
+                length      = 3
+                ticked      = 0
               },
               {
                 id          = "delve"
                 name        = "Delve"
                 description = ""
-                current     = 0
-                maximum     = 3
+                length      = 3
+                ticked      = 0
               },
               {
                 id          = "hunt"
                 name        = "Hunt"
                 description = ""
-                current     = 0
-                maximum     = 3
+                length      = 3
+                ticked      = 0
               },
               {
                 id          = "outwit"
                 name        = "Outwit"
                 description = ""
-                current     = 0
-                maximum     = 3
+                length      = 3
+                ticked      = 0
               },
               {
                 id          = "study"
                 name        = "Study"
                 description = ""
-                current     = 0
-                maximum     = 3
+                length      = 3
+                ticked      = 0
               },
               {
                 id          = "sway"
                 name        = "Sway"
                 description = ""
-                current     = 0
-                maximum     = 3
+                length      = 3
+                ticked      = 0
               }
             ]
-            showEmpty = false
+            showEmpty = true
           })
           position = 2
         },
@@ -175,7 +175,7 @@ resource "aws_dynamodb_table_item" "template_wildsea_basic_en" {
                 states      = ["unticked", "unticked", "unticked"]
               }
             ]
-            showEmpty = false
+            showEmpty = true
           })
           position = 3
         }

--- a/terraform/module/wildsea/templates.tlh.tf
+++ b/terraform/module/wildsea/templates.tlh.tf
@@ -67,25 +67,25 @@ resource "aws_dynamodb_table_item" "template_wildsea_basic_tlh" {
                 id          = "iron"
                 name        = "baS"
                 description = ""
-                current     = 2
-                maximum     = 5
+                length      = 5
+                ticked      = 2
               },
               {
                 id          = "teeth"
                 name        = "DIrgh"
                 description = ""
-                current     = 2
-                maximum     = 5
+                length      = 5
+                ticked      = 2
               },
               {
                 id          = "veils"
                 name        = "Sor"
                 description = ""
-                current     = 2
-                maximum     = 5
+                length      = 5
+                ticked      = 2
               }
             ]
-            showEmpty = false
+            showEmpty = true
           })
           position = 1
         },
@@ -98,46 +98,46 @@ resource "aws_dynamodb_table_item" "template_wildsea_basic_tlh" {
                 id          = "break"
                 name        = "DIch"
                 description = ""
-                current     = 0
-                maximum     = 3
+                length      = 3
+                ticked      = 0
               },
               {
                 id          = "delve"
                 name        = "nej"
                 description = ""
-                current     = 0
-                maximum     = 3
+                length      = 3
+                ticked      = 0
               },
               {
                 id          = "hunt"
                 name        = "DIch"
                 description = ""
-                current     = 0
-                maximum     = 3
+                length      = 3
+                ticked      = 0
               },
               {
                 id          = "outwit"
                 name        = "val"
                 description = ""
-                current     = 0
-                maximum     = 3
+                length      = 3
+                ticked      = 0
               },
               {
                 id          = "study"
                 name        = "ghoj"
                 description = ""
-                current     = 0
-                maximum     = 3
+                length      = 3
+                ticked      = 0
               },
               {
                 id          = "sway"
                 name        = "DIch"
                 description = ""
-                current     = 0
-                maximum     = 3
+                length      = 3
+                ticked      = 0
               }
             ]
-            showEmpty = false
+            showEmpty = true
           })
           position = 2
         },
@@ -175,7 +175,7 @@ resource "aws_dynamodb_table_item" "template_wildsea_basic_tlh" {
                 states      = ["unticked", "unticked", "unticked"]
               }
             ]
-            showEmpty = false
+            showEmpty = true
           })
           position = 3
         }


### PR DESCRIPTION
## Summary
- Fixed TRACKABLE sections using incorrect field names (`current`/`maximum` instead of `ticked`/`length`), which caused NaN values in Edges and Skills
- Fixed `showEmpty` setting for all sections (Edges, Skills, Resources) to properly display empty items
- Applied fixes to both English and Klingon templates

## Test plan
- [x] Deployed to dev environment
- [x] All tests pass
- [x] Verify new characters created with Basic Character template display correctly
- [x] Verify ticks show proper values instead of NaN

Resolves #1139

🤖 Generated with [Claude Code](https://claude.com/claude-code)