### PR TITLE
Implement Cognito Managed Login with branding

### DIFF
--- a/.github/workflows/environment-main-deploy.yaml
+++ b/.github/workflows/environment-main-deploy.yaml
@@ -52,6 +52,8 @@ jobs:
           echo "No weapon data secret found, proceeding without weapon presets"
         fi
 
+    - name: Generate favicon
+      run: make favicon
 
     - name: Configure AWS Access
       uses: aws-actions/configure-aws-credentials@f226b0540e0de24b4ff8b81fdd0524c71cde478f

--- a/.github/workflows/environment-main-plan.yaml
+++ b/.github/workflows/environment-main-plan.yaml
@@ -50,6 +50,9 @@ jobs:
           echo "No weapon data secret found, proceeding without weapon presets"
         fi
 
+    - name: Generate favicon
+      run: make favicon
+
     - name: Configure AWS Access
       uses: aws-actions/configure-aws-credentials@f226b0540e0de24b4ff8b81fdd0524c71cde478f
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ test-scripts/*.json
 
 # Copyrighted game data (must be created by users who own the books)
 deltagreen-weapons.json
+
+# Generated favicon
+terraform/module/wildsea/favicon.ico

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ terraform/environment/aws/.apply: terraform/environment/aws/*.tf terraform/modul
 	AUTO_APPROVE=yes ./terraform/environment/aws/deploy.sh $(ACCOUNT_ID)
 	touch $@
 
-terraform/environment/wildsea-dev/plan.tfplan: terraform/environment/wildsea-dev/*.tf terraform/module/wildsea/*.tf terraform/environment/wildsea-dev/.terraform $(GRAPHQL_JS) lambda/generatePresignedUrl/lambda_function.py
+terraform/environment/wildsea-dev/plan.tfplan: terraform/environment/wildsea-dev/*.tf terraform/module/wildsea/*.tf terraform/environment/wildsea-dev/.terraform $(GRAPHQL_JS) lambda/generatePresignedUrl/lambda_function.py terraform/module/wildsea/favicon.ico
 	cd terraform/environment/wildsea-dev ; ../../../scripts/run-as.sh $(RO_ROLE) \
 		terraform plan -out=./plan.tfplan
 

--- a/terraform/module/wildsea/cognito.tf
+++ b/terraform/module/wildsea/cognito.tf
@@ -1,5 +1,6 @@
 resource "aws_cognito_user_pool" "cognito" {
-  name = var.prefix
+  name           = var.prefix
+  user_pool_tier = "ESSENTIALS"
 
   admin_create_user_config {
     allow_admin_create_user_only = true
@@ -204,14 +205,163 @@ resource "aws_iam_role_policy_attachment" "cognito_unauth" {
 }
 
 resource "aws_cognito_user_pool_domain" "cognito" {
-  domain       = lower(var.prefix)
-  user_pool_id = aws_cognito_user_pool.cognito.id
+  domain                = lower(var.prefix)
+  user_pool_id          = aws_cognito_user_pool.cognito.id
+  managed_login_version = 2
 }
 
-resource "aws_cognito_user_pool_ui_customization" "cognito" {
+resource "aws_cognito_managed_login_branding" "cognito" {
+  user_pool_id = aws_cognito_user_pool.cognito.id
   client_id    = aws_cognito_user_pool_client.cognito.id
-  css          = file("${path.module}/../../cognito-ui.css")
-  user_pool_id = aws_cognito_user_pool_domain.cognito.user_pool_id
+
+  # Favicon - ICO format
+  asset {
+    bytes      = filebase64("${path.module}/favicon.ico")
+    category   = "FAVICON_ICO"
+    color_mode = "LIGHT"
+    extension  = "ICO"
+  }
+
+  settings = jsonencode({
+    categories = {
+      form = {
+        displayGraphics = false
+        location = {
+          horizontal = "CENTER"
+          vertical   = "CENTER"
+        }
+      }
+      global = {
+        colorSchemeMode = "LIGHT"
+      }
+    }
+    componentClasses = {
+      buttons = {
+        borderRadius = 8
+      }
+      input = {
+        borderRadius = 8
+        lightMode = {
+          defaults = {
+            backgroundColor = "ffffffff"
+            borderColor     = "dee2e6ff"
+          }
+          placeholderColor = "6c757dff"
+        }
+      }
+      link = {
+        lightMode = {
+          defaults = {
+            textColor = "0066ccff"
+          }
+          hover = {
+            textColor = "0052a3ff"
+          }
+        }
+      }
+      focusState = {
+        lightMode = {
+          borderColor = "0066ccff"
+        }
+      }
+      inputLabel = {
+        lightMode = {
+          textColor = "212529ff"
+        }
+      }
+      divider = {
+        lightMode = {
+          borderColor = "dee2e6ff"
+        }
+      }
+    }
+    components = {
+      primaryButton = {
+        lightMode = {
+          defaults = {
+            backgroundColor = "1e7e34ff"
+            textColor       = "ffffffff"
+          }
+          hover = {
+            backgroundColor = "155724ff"
+            textColor       = "ffffffff"
+          }
+          active = {
+            backgroundColor = "155724ff"
+            textColor       = "ffffffff"
+          }
+        }
+      }
+      secondaryButton = {
+        lightMode = {
+          defaults = {
+            backgroundColor = "ffffffff"
+            textColor       = "212529ff"
+            borderColor     = "dee2e6ff"
+          }
+          hover = {
+            backgroundColor = "f8f9faff"
+            textColor       = "212529ff"
+            borderColor     = "dee2e6ff"
+          }
+          active = {
+            backgroundColor = "f8f9faff"
+            textColor       = "212529ff"
+            borderColor     = "dee2e6ff"
+          }
+        }
+      }
+      idpButton = {
+        standard = {
+          lightMode = {
+            defaults = {
+              backgroundColor = "ffffffff"
+              textColor       = "495057ff"
+              borderColor     = "dee2e6ff"
+            }
+            hover = {
+              backgroundColor = "f8f9faff"
+              textColor       = "212529ff"
+              borderColor     = "c6c6cdff"
+            }
+            active = {
+              backgroundColor = "e9ecefff"
+              textColor       = "212529ff"
+              borderColor     = "c6c6cdff"
+            }
+          }
+        }
+      }
+      pageBackground = {
+        image = {
+          enabled = false
+        }
+        lightMode = {
+          color = "f8f9faff"
+        }
+      }
+      pageText = {
+        lightMode = {
+          bodyColor        = "212529ff"
+          headingColor     = "212529ff"
+          descriptionColor = "212529ff"
+        }
+      }
+      favicon = {
+        enabledTypes = ["ICO"]
+      }
+      form = {
+        backgroundImage = {
+          enabled = false
+        }
+        lightMode = {
+          backgroundColor = "ffffffff"
+          borderColor     = "e9ecefff"
+        }
+        borderRadius = 12
+      }
+    }
+  })
 
   depends_on = [aws_cognito_user_pool_domain.cognito]
 }

--- a/ui/ui.mk
+++ b/ui/ui.mk
@@ -68,3 +68,13 @@ ui-test: ui/node_modules
 	else \
 		cd ui && ./node_modules/.bin/jest --coverage ; \
 	fi
+
+.PHONY: favicon
+favicon: terraform/module/wildsea/favicon.ico
+
+terraform/module/wildsea/favicon.ico: ui/public/favicon.webp
+	docker run --rm \
+		-v "$$(pwd):/work" \
+		-w /work \
+		alpine:latest \
+		sh -c 'apk add --no-cache imagemagick libwebp-tools && magick ui/public/favicon.webp -define icon:auto-resize=48,32,16 terraform/module/wildsea/favicon.ico && chown $$(id -u):$$(id -g) terraform/module/wildsea/favicon.ico'


### PR DESCRIPTION
## Summary
- Resolves #1142
- Upgrades Cognito to Essentials tier and implements Managed Login v2
- Removes deprecated UI customization (incompatible with Managed Login v2)
- Adds custom branding that matches application styling
- Implements favicon generation pipeline

## Changes
- **Cognito Configuration**: Upgraded to `user_pool_tier = "ESSENTIALS"` and `managed_login_version = 2`
- **Branding**: Added `aws_cognito_managed_login_branding` resource with custom styling matching default.css theme
- **Favicon**: Created Makefile target to convert favicon.webp to favicon.ico using Docker + ImageMagick
- **Color Scheme**: Green action buttons (#1e7e34), light gray background (#f8f9fa), neutral text colors
- **Build Process**: Added favicon as dependency for terraform plan/apply, added to .gitignore

## Test plan
- [x] Login page loads successfully
- [x] Styling matches application theme colors
- [x] Favicon displays correctly
- [x] Google OAuth button styled appropriately
- [x] Deployed to dev environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)