### PR TITLE
feat: enable Renovate auto-merge for minor/patch/dev dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,19 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":dependencyDashboard"
+    ":dependencyDashboard",
+    ":automergePr"
+  ],
+  "platformAutomerge": true,
+  "automergeStrategy": "squash",
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
+      "matchDepTypes": ["devDependencies"],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds Renovate auto-merge configuration for minor, patch, pin, digest, and dev dependency updates
- Major production dependency updates still require manual review
- Uses squash merge strategy to match existing conventions

## Test plan
- [ ] Verify CI passes on this PR (confirms branch protection is working)
- [ ] After merge, wait for next Renovate PR to confirm auto-merge triggers
- [ ] Check Renovate Dependency Dashboard issue for automerge status

🤖 Generated with [Claude Code](https://claude.com/claude-code)